### PR TITLE
Support Ruby-GNOME2/GdkPixbuf2 >= 3.0.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+sample/out_*.jpg
+sample/*.icc.jpg

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,3 @@
+AllCops:
+  Excludes:
+   - spec/*

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,1 @@
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'

--- a/lib/morandi.rb
+++ b/lib/morandi.rb
@@ -1,4 +1,4 @@
-require "morandi/version"
+require 'morandi/version'
 require 'gtk2/base'
 require 'cairo'
 require 'gdk_pixbuf2'
@@ -12,10 +12,10 @@ require 'morandi/redeye'
 
 module Morandi
   module_function
+
   def process(file_in, options, out_file, local_options = {})
     pro = ImageProcessor.new(file_in, options, local_options)
     pro.process!
     pro.write_to_jpeg(out_file)
   end
 end
-

--- a/lib/morandi/image-ops.rb
+++ b/lib/morandi/image-ops.rb
@@ -2,334 +2,349 @@ require 'pango'
 require 'colorscore'
 
 module Morandi
-class ImageOp
-  class << self
-    def new_from_hash(hash)
-      op = allocate()
-      hash.each_pair do |key,val|
-        op.instance_variable_set("@#{key}", val) if op.respond_to?(key.intern)
+  class ImageOp
+    class << self
+      def new_from_hash(hash)
+        op = allocate
+        hash.each_pair do |key, val|
+          op.instance_variable_set("@#{key}", val) if op.respond_to?(key.intern)
+        end
+        op
       end
-      op
+    end
+    def initialize; end
+
+    def priority
+      100
     end
   end
-  def initialize()
-  end
-  def priority
-    100
-  end
-end
-class Crop < ImageOp
-  attr_accessor :area
-  def initialize(area=nil)
-    super()
-    @area = area
-  end
-  def constrain(val,min,max)
-    if val < min
-      min
-    elsif val > max
-      max
-    else
-      val
+  class Crop < ImageOp
+    attr_accessor :area
+    def initialize(area = nil)
+      super()
+      @area = area
     end
-  end
-  def call(image, pixbuf)
-    if @area and (not @area.width.zero?) and (not @area.height.zero?)
-      # NB: Cheap - fast & shares memory
-      Gdk::Pixbuf.new(pixbuf, @area.x, @area.y,
-          @area.width, @area.height)
-    else
-      pixbuf
-    end
-  end
-end
-class Rotate < ImageOp
-  attr_accessor :angle
-  def initialize(angle=0)
-    super()
-    @angle = angle
-  end
-  def call(image, pixbuf)
-    if @angle.zero?
-      pixbuf
-    else
-      case @angle
-      when 0, 90, 180, 270
-        PixbufUtils::rotate(pixbuf, @angle)
+
+    def constrain(val, min, max)
+      if val < min
+        min
+      elsif val > max
+        max
       else
-        raise "Not a valid angle"
+        val
+      end
+    end
+
+    def call(_image, pixbuf)
+      if @area && !@area.width.zero? && !@area.height.zero?
+        # NB: Cheap - fast & shares memory
+        GdkPixbuf::Pixbuf.new(pixbuf, @area.x, @area.y,
+                              @area.width, @area.height)
+      else
+        pixbuf
       end
     end
   end
-end
-class Straighten < ImageOp
-  attr_accessor :angle
-  def initialize(angle=0)
-    super()
-    @angle = angle
+  class Rotate < ImageOp
+    attr_accessor :angle
+    def initialize(angle = 0)
+      super()
+      @angle = angle
+    end
+
+    def call(_image, pixbuf)
+      if @angle.zero?
+        pixbuf
+      else
+        case @angle
+        when 0, 90, 180, 270
+          PixbufUtils.rotate(pixbuf, @angle)
+        else
+          raise 'Not a valid angle'
+        end
+      end
+    end
   end
-  def call(image, pixbuf)
-    if @angle.zero?
-      pixbuf
-    else
+  class Straighten < ImageOp
+    attr_accessor :angle
+    def initialize(angle = 0)
+      super()
+      @angle = angle
+    end
+
+    def call(_image, pixbuf)
+      if @angle.zero?
+        pixbuf
+      else
+        surface = Cairo::ImageSurface.new(:rgb24, pixbuf.width, pixbuf.height)
+
+        rotationValueRad = @angle * (Math::PI / 180)
+
+        ratio = pixbuf.width.to_f / pixbuf.height
+        rh = pixbuf.height / ((ratio * Math.sin(rotationValueRad.abs)) + Math.cos(rotationValueRad.abs))
+        scale = pixbuf.height / rh.to_f.abs
+
+        a_ratio = pixbuf.height.to_f / pixbuf.width
+        a_rh = pixbuf.width / ((a_ratio * Math.sin(rotationValueRad.abs)) + Math.cos(rotationValueRad.abs))
+        a_scale = pixbuf.width / a_rh.to_f.abs
+
+        scale = a_scale if a_scale > scale
+
+        cr = Cairo::Context.new(surface)
+        # p [@angle, rotationValueRad, rh, scale, pixbuf.height]
+
+        cr.translate(pixbuf.width / 2.0, pixbuf.height / 2.0)
+        cr.rotate(rotationValueRad)
+        cr.scale(scale, scale)
+        cr.translate(pixbuf.width / -2.0, pixbuf.height / - 2.0)
+        cr.set_source_pixbuf(pixbuf)
+
+        cr.rectangle(0, 0, pixbuf.width, pixbuf.height)
+        cr.paint(1.0)
+        final_pb = surface.to_pixbuf
+        cr.destroy
+        surface.destroy
+        final_pb
+      end
+    end
+  end
+
+  class ImageCaption < ImageOp
+    attr_accessor :text, :font, :position
+    def initialize
+      super()
+    end
+
+    def font
+      @font || "Open Sans Condensed Light #{([@pixbuf.width, @pixbuf.height].max / 80.0).to_i}"
+    end
+
+    def position
+      @position ||
+        (@pixbuf ? ([[@pixbuf.width, @pixbuf.height].max / 20] * 2) : [100, 100])
+    end
+
+    def call(_image, pixbuf)
+      @pixbuf = pixbuf
       surface = Cairo::ImageSurface.new(:rgb24, pixbuf.width, pixbuf.height)
-
-      rotationValueRad = @angle * (Math::PI/180)
-
-      ratio = pixbuf.width.to_f/pixbuf.height
-      rh = (pixbuf.height) / ((ratio * Math.sin(rotationValueRad.abs)) + Math.cos(rotationValueRad.abs))
-      scale = pixbuf.height / rh.to_f.abs
-
-      a_ratio = pixbuf.height.to_f/pixbuf.width
-      a_rh = (pixbuf.width) / ((a_ratio * Math.sin(rotationValueRad.abs)) + Math.cos(rotationValueRad.abs))
-      a_scale = pixbuf.width / a_rh.to_f.abs
-
-      scale = a_scale if a_scale > scale
-
       cr = Cairo::Context.new(surface)
-      #p [@angle, rotationValueRad, rh, scale, pixbuf.height]
 
-      cr.translate(pixbuf.width / 2.0, pixbuf.height / 2.0)
-      cr.rotate(rotationValueRad)
-      cr.scale(scale, scale)
-      cr.translate(pixbuf.width / -2.0, pixbuf.height / - 2.0)
+      cr.save do
+        cr.set_source_pixbuf(pixbuf)
+        # cr.rectangle(0, 0, pixbuf.width, pixbuf.height)
+        cr.paint(1.0)
+        cr.translate(*position)
+
+        layout = cr.create_pango_layout
+        layout.set_text(text)
+        fd = Pango::FontDescription.new(font)
+        layout.font_description = fd
+        layout.set_width((pixbuf.width - position[0] - 100) * Pango::SCALE)
+        layout.context_changed
+        ink, = layout.pixel_extents
+        cr.set_source_rgba(0, 0, 0, 0.3)
+        cr.rectangle(-25, -25, ink.width + 50, ink.height + 50)
+        cr.fill
+        cr.set_source_rgb(1, 1, 1)
+        cr.show_pango_layout(layout)
+      end
+
+      final_pb = surface.to_pixbuf
+      cr.destroy
+      surface.destroy
+      final_pb
+    end
+  end
+
+  class ImageBorder < ImageOp
+    attr_accessor :style, :colour, :crop, :size, :print_size, :shrink, :border_size
+    def initialize(style = 'none', colour = 'white')
+      super()
+      @style = style
+      @colour = colour
+    end
+
+    def call(_image, pixbuf)
+      return pixbuf unless %w(square retro).include? @style
+      surface = Cairo::ImageSurface.new(:rgb24, pixbuf.width, pixbuf.height)
+      cr = Cairo::Context.new(surface)
+
+      img_width = pixbuf.width
+      img_height = pixbuf.height
+
+      cr.save do
+        if @crop
+          if @crop[0] < 0 || @crop[1] < 0
+            img_width = size[0]
+            img_height = size[1]
+            cr.translate(- @crop[0], - @crop[1])
+          end
+        end
+
+        cr.save do
+          cr.set_operator :source
+          cr.set_source_rgb 1, 1, 1
+          cr.paint
+
+          cr.rectangle(0, 0, img_width, img_height)
+          case colour
+          when 'dominant'
+            pixbuf.scale_max(400).save(fn = "/tmp/hist-#{$PROCESS_ID}.#{Time.now.to_i}", 'jpeg')
+            hgram = Colorscore::Histogram.new(fn)
+            begin
+              File.unlink(fn)
+            rescue
+              nil
+            end
+            col = hgram.scores.first[1]
+            cr.set_source_rgb col.red / 256.0, col.green / 256.0, col.blue / 256.0
+          when 'retro'
+            cr.set_source_rgb 1, 1, 0.8
+          when 'black'
+            cr.set_source_rgb 0, 0, 0
+          else
+            cr.set_source_rgb 1, 1, 1
+          end
+          cr.fill
+        end
+      end
+
+      border_scale = [img_width, img_height].max.to_f / print_size.max.to_i
+      size = @border_size
+      size *= border_scale
+      x = size
+      y = size
+
+      # This biggest impact will be on the smallest side, so to avoid white
+      # edges between photo and border scale by the longest changed side.
+      longest_side = [pixbuf.width, pixbuf.height].max.to_f
+
+      # Should be less than 1
+      pb_scale = (longest_side - (size * 2)) / longest_side
+
+      if @crop
+        if @crop[0] < 0 || @crop[1] < 0
+          x -= @crop[0]
+          y -= @crop[1]
+        end
+      end
+
+      case style
+      when 'retro'
+        CairoUtils.rounded_rectangle(cr, x, y,
+                                     img_width + x - (size * 2), img_height + y - (size * 2), size)
+      when 'square'
+        cr.rectangle(x, y, img_width - (size * 2), img_height - (size * 2))
+      end
+      cr.clip
+
+      if @shrink
+        cr.translate(size, size)
+        cr.scale(pb_scale, pb_scale)
+      end
       cr.set_source_pixbuf(pixbuf)
-
       cr.rectangle(0, 0, pixbuf.width, pixbuf.height)
+
       cr.paint(1.0)
       final_pb = surface.to_pixbuf
       cr.destroy
       surface.destroy
-      return final_pb
+      final_pb
     end
   end
-end
 
-class ImageCaption < ImageOp
-  attr_accessor :text, :font, :position
-  def initialize()
-    super()
-  end
-
-  def font
-    @font || "Open Sans Condensed Light #{ ([@pixbuf.width,@pixbuf.height].max/80.0).to_i }"
-  end
-
-  def position
-    @position ||
-    (@pixbuf ? ([ [@pixbuf.width,@pixbuf.height].max/20 ] * 2) : [100, 100])
-  end
-
-  def call(image, pixbuf)
-    @pixbuf = pixbuf
-    surface = Cairo::ImageSurface.new(:rgb24, pixbuf.width, pixbuf.height)
-    cr = Cairo::Context.new(surface)
-
-    cr.save do
-      cr.set_source_pixbuf(pixbuf)
-      #cr.rectangle(0, 0, pixbuf.width, pixbuf.height)
-      cr.paint(1.0)
-      cr.translate(*self.position)
-
-      layout = cr.create_pango_layout
-      layout.set_text(self.text)
-      fd = Pango::FontDescription.new(self.font)
-      layout.font_description = fd
-      layout.set_width((pixbuf.width - self.position[0] - 100)*Pango::SCALE)
-      layout.context_changed
-      ink, _ = layout.pixel_extents
-      cr.set_source_rgba(0, 0, 0, 0.3)
-      cr.rectangle(-25, -25, ink.width + 50, ink.height + 50)
-      cr.fill
-      cr.set_source_rgb(1, 1, 1)
-      cr.show_pango_layout(layout)
+  class Gamma < ImageOp
+    attr_reader :gamma
+    def initialize(gamma = 1.0)
+      super()
+      @gamma = gamma
     end
 
-
-    final_pb = surface.to_pixbuf
-    cr.destroy
-    surface.destroy
-    return final_pb
-  end
-end
-
-class ImageBorder < ImageOp
-  attr_accessor :style, :colour, :crop, :size, :print_size, :shrink, :border_size
-  def initialize(style='none', colour='white')
-    super()
-    @style = style
-    @colour = colour
-  end
-
-  def call(image, pixbuf)
-    return pixbuf unless %w[square retro].include? @style
-    surface = Cairo::ImageSurface.new(:rgb24, pixbuf.width, pixbuf.height)
-    cr = Cairo::Context.new(surface)
-
-    img_width = pixbuf.width
-    img_height = pixbuf.height
-
-    cr.save do
-      if @crop
-        if @crop[0] < 0 || @crop[1] < 0
-          img_width = size[0]
-          img_height = size[1]
-          cr.translate( - @crop[0], - @crop[1])
-        end
-      end
-
-      cr.save do
-        cr.set_operator :source
-        cr.set_source_rgb 1, 1, 1
-        cr.paint
-
-        cr.rectangle(0, 0, img_width, img_height)
-        case colour
-        when 'dominant'
-          pixbuf.scale_max(400).save(fn="/tmp/hist-#{$$}.#{Time.now.to_i}", 'jpeg')
-          hgram = Colorscore::Histogram.new(fn)
-          File.unlink(fn) rescue nil
-          col =  hgram.scores.first[1]
-          cr.set_source_rgb col.red/256.0, col.green/256.0, col.blue/256.0
-        when 'retro'
-          cr.set_source_rgb 1, 1, 0.8
-        when 'black'
-          cr.set_source_rgb 0, 0, 0
-        else
-          cr.set_source_rgb 1, 1, 1
-        end
-        cr.fill
+    def call(_image, pixbuf)
+      if @gamma == 1.0
+        pixbuf
+      else
+        PixbufUtils.gamma(pixbuf, @gamma)
       end
     end
 
-    border_scale =  [img_width,img_height].max.to_f / print_size.max.to_i
-    size = @border_size
-    size *= border_scale
-    x, y = size, size
-
-    # This biggest impact will be on the smallest side, so to avoid white
-    # edges between photo and border scale by the longest changed side.
-    longest_side = [pixbuf.width, pixbuf.height].max.to_f
-
-    # Should be less than 1
-    pb_scale = (longest_side - (size * 2)) / longest_side
-
-    if @crop
-      if @crop[0] < 0 || @crop[1] < 0
-        x -= @crop[0]
-        y -= @crop[1]
-      end
+    def priority
+      90
     end
-
-    case style
-    when 'retro'
-      CairoUtils.rounded_rectangle(cr, x, y,
-                                   img_width + x - (size*2), img_height+y-(size*2), size)
-    when 'square'
-        cr.rectangle(x, y, img_width - (size*2), img_height - (size*2))
-    end
-    cr.clip()
-
-    if @shrink
-      cr.translate(size, size)
-      cr.scale(pb_scale, pb_scale)
-    end
-    cr.set_source_pixbuf(pixbuf)
-    cr.rectangle(0, 0, pixbuf.width, pixbuf.height)
-
-    cr.paint(1.0)
-    final_pb = surface.to_pixbuf
-    cr.destroy
-    surface.destroy
-    return final_pb
   end
-end
 
-class Gamma < ImageOp
-  attr_reader :gamma
-  def initialize(gamma=1.0)
-    super()
-    @gamma = gamma
+  class RedEyeOp < ImageOp
+    attr_reader :x1, :y1, :x2, :y2, :sensitivity, :no_eyes
+    attr_accessor :order
+    def initialize(x1, y1, x2, y2, sensitivity, no_eyes)
+      super()
+      require 'redeye'
+      x1, x2 = x2, x1 if x1 > x2
+      y1, y2 = y2, y1 if y1 > y2
+      @x1 = x1
+      @y1 = y1
+      @x2 = x2
+      @y2 = y2
+      @sensitivity = sensitivity
+      @no_eyes = no_eyes
+    end
+
+    def call(_image, pixbuf)
+      @x2 = pixbuf.width if @x2 >= pixbuf.width
+      @y2 = pixbuf.height if @y2 >= pixbuf.height
+      @x1 = @x2 - 1 if @x1 >= @x2
+      @y1 = @y2 - 1 if @y1 >= @y2
+      redeye = ::RedEye.new(pixbuf.dup, @x1, @y1, @x2, @y2)
+      blobs = redeye.identify_blobs(@sensitivity).reject do |i|
+        i.noPixels < 2 || !i.squareish?(0.5, 0.4)
+      end.sort_by(&:noPixels)
+      biggest = blobs.size > @no_eyes ? blobs[-1 * @no_eyes..-1] : blobs
+      biggest.each { |blob| redeye.correct_blob(blob.id) }
+      redeye.pixbuf
+    end
+
+    def priority
+      20 + @order
+    end
   end
-  def call(image, pixbuf)
-    if @gamma == 1.0
+
+  class Colourify < ImageOp
+    attr_reader :op
+    def initialize(op, alpha = 255)
+      super()
+      @op = op
+      @alpha = alpha
+    end
+
+    def alpha
+      @alpha || 255
+    end
+
+    def sepia(pixbuf)
+      PixbufUtils.tint(pixbuf, 25, 5, -25, alpha)
+    end
+
+    def bluetone(pixbuf)
+      PixbufUtils.tint(pixbuf, -10, 5, 25, alpha)
+    end
+
+    def null(pixbuf)
       pixbuf
-    else
-      PixbufUtils.gamma(pixbuf, @gamma)
+    end
+    alias full null # WebKiosk
+    alias colour null # WebKiosk
+
+    def greyscale(pixbuf)
+      PixbufUtils.tint(pixbuf, 0, 0, 0, alpha)
+    end
+    alias bw greyscale # WebKiosk
+
+    def call(_image, pixbuf)
+      if @op && respond_to?(@op)
+        __send__(@op, pixbuf)
+      else
+        pixbuf # Default is nothing
+      end
     end
   end
-  def priority
-    90
-  end
-end
-
-class RedEyeOp < ImageOp
-  attr_reader :x1, :y1, :x2, :y2, :sensitivity, :no_eyes
-  attr_accessor :order
-  def initialize(x1, y1, x2, y2, sensitivity, no_eyes)
-    super()
-    require 'redeye'
-    x1, x2 = x2, x1 if x1 > x2
-    y1, y2 = y2, y1 if y1 > y2
-    @x1, @y1, @x2, @y2, @sensitivity, @no_eyes =
-      x1, y1, x2, y2, sensitivity, no_eyes
-  end
-  def call(image, pixbuf)
-    @x2 = pixbuf.width if @x2 >= pixbuf.width
-    @y2 = pixbuf.height if @y2 >= pixbuf.height
-    @x1 = @x2 - 1 if @x1 >= @x2
-    @y1 = @y2 - 1 if @y1 >= @y2
-    redeye = ::RedEye.new(pixbuf.dup, @x1, @y1, @x2, @y2)
-    blobs = redeye.identify_blobs(@sensitivity).reject { |i|
-      i.noPixels < 2 or ! i.squareish?(0.5, 0.4)
-    }.sort_by { |i| i.noPixels }
-    biggest = blobs.size > @no_eyes ?  blobs[-1 * @no_eyes..-1] : blobs
-    biggest.each { |blob| redeye.correct_blob(blob.id) }
-    redeye.pixbuf
-  end
-  def priority
-    20 + @order
-  end
-end
-
-class Colourify < ImageOp
-  attr_reader :op
-  def initialize(op, alpha=255)
-    super()
-    @op = op
-    @alpha = alpha
-  end
-
-  def alpha
-    @alpha || 255
-  end
-
-  def sepia(pixbuf)
-    PixbufUtils.tint(pixbuf, 25, 5, -25, alpha)
-  end
-
-  def bluetone(pixbuf)
-    PixbufUtils.tint(pixbuf, -10, 5, 25, alpha)
-  end
-
-  def null(pixbuf)
-    pixbuf
-  end
-  alias :full :null # WebKiosk
-  alias :colour :null # WebKiosk
-
-  def greyscale(pixbuf)
-    PixbufUtils.tint(pixbuf, 0, 0, 0, alpha)
-  end
-  alias :bw :greyscale # WebKiosk
-
-  def call(image, pixbuf)
-    if @op and respond_to?(@op)
-      __send__(@op, pixbuf)
-    else
-      pixbuf # Default is nothing
-    end
-  end
-end
-
 end

--- a/lib/morandi/image_processor.rb
+++ b/lib/morandi/image_processor.rb
@@ -1,6 +1,7 @@
 require 'morandi/profiled_pixbuf'
 require 'morandi/redeye'
 
+# Class for applying changes to images
 class Morandi::ImageProcessor
   attr_reader :options, :pb
   attr_accessor :config
@@ -9,7 +10,7 @@ class Morandi::ImageProcessor
     "#{path}.icc.jpg"
   end
 
-  def initialize(file, user_options, local_options={})
+  def initialize(file, user_options, local_options = {})
     @file = file
 
     user_options.keys.grep(/^path/).each { |k| user_options.delete(k) }
@@ -19,11 +20,12 @@ class Morandi::ImageProcessor
     @local_options = local_options
 
     @scale_to = @options['output.max']
-    @width, @height = @options['output.width'], @options['output.height']
+    @width    = @options['output.width']
+    @height   = @options['output.height']
 
     if @file.is_a?(String)
-      get_pixbuf
-    elsif @file.is_a?(Gdk::Pixbuf) or @file.is_a?(Morandi::ProfiledPixbuf)
+      load_pixbuf
+    elsif @file.is_a?(GdkPixbuf::Pixbuf) || @file.is_a?(Morandi::ProfiledPixbuf)
       @pb = @file
       @scale = 1.0
     end
@@ -59,7 +61,7 @@ class Morandi::ImageProcessor
     @pb
   end
 
-  def write_to_png(fn, orientation=:any)
+  def write_to_png(fn, orientation = :any)
     pb = @pb
 
     case orientation
@@ -72,24 +74,39 @@ class Morandi::ImageProcessor
   end
 
   def write_to_jpeg(fn, quality = 97)
-    @pb.save(fn, 'jpeg', :quality => quality)
+    @pb.save('jpeg', filename: fn, quality: quality.to_s)
   end
 
-protected
-  def get_pixbuf
-    _, width, height = Gdk::Pixbuf.get_file_info(@file)
+  protected
 
+  def load_pixbuf
     if @scale_to
-      @pb = Morandi::ProfiledPixbuf.new(@file, @scale_to, @scale_to, @local_options)
+      _, width, height = GdkPixbuf::Pixbuf.get_file_info(@file)
+      @pb = load_pixbuf_scaled
+
       @src_max = [width, height].max
-      @actual_max = [@pb.width, @pb.height].max
     else
-      @pb = Morandi::ProfiledPixbuf.new(@file, @local_options)
+      @pb = load_pixbuf_simple
       @src_max = [@pb.width, @pb.height].max
-      @actual_max = [@pb.width, @pb.height].max
     end
 
+    @actual_max = [@pb.width, @pb.height].max
+
     @scale = @actual_max / @src_max.to_f
+  end
+
+  def load_pixbuf_simple
+    Morandi::ProfiledPixbuf.new({
+                                  file: @file
+                                }, @local_options)
+  end
+
+  def load_pixbuf_scaled
+    Morandi::ProfiledPixbuf.new({
+                                        file: @file,
+                                        width: @scale_to,
+                                        height: @scale_to
+                                      }, @local_options)
   end
 
   SHARPEN = [
@@ -97,19 +114,20 @@ protected
     -1,  2,  2,  2, -1,
     -1,  2,  8,  2, -1,
     -1,  2,  2,  2, -1,
-    -1, -1, -1, -1, -1,
-  ]
+    -1, -1, -1, -1, -1
+  ].freeze
+
   BLUR = [
     0, 1, 1, 1, 0,
     1, 1, 1, 1, 1,
     1, 1, 1, 1, 1,
     1, 1, 1, 1, 1,
-    0, 1, 1, 1, 0,
-  ]
+    0, 1, 1, 1, 0
+  ].freeze
 
   def apply_colour_manipulations!
     if options['brighten'].to_i.nonzero?
-      brighten = [ [ 5 * options['brighten'], -100 ].max, 100 ].min
+      brighten = [[5 * options['brighten'], -100].max, 100].min
       @pb = PixbufUtils.brightness(@pb, brighten)
     end
 
@@ -118,7 +136,7 @@ protected
     end
 
     if options['contrast'].to_i.nonzero?
-      @pb = PixbufUtils.contrast(@pb, [ [ 5 * options['contrast'], -100 ].max, 100 ].min)
+      @pb = PixbufUtils.contrast(@pb, [[5 * options['contrast'], -100].max, 100].min)
     end
 
     if options['sharpen'].to_i.nonzero?
@@ -127,7 +145,7 @@ protected
           @pb = PixbufUtils.filter(@pb, SHARPEN, SHARPEN.inject(0, &:+))
         end
       elsif options['sharpen'] < 0
-        [ (options['sharpen']*-1), 5].min.times do
+        [(options['sharpen'] * -1), 5].min.times do
           @pb = PixbufUtils.filter(@pb, BLUR, BLUR.inject(0, &:+))
         end
       end
@@ -135,27 +153,21 @@ protected
   end
 
   def apply_redeye!
-    for eye in options['redeye'] || []
+    (options['redeye'] || []).each do |eye|
       @pb = Morandi::RedEye::TapRedEye.tap_on(@pb, eye[0] * @scale, eye[1] * @scale)
     end
   end
 
   def angle
     a = options['angle'].to_i
-    if a
-      (360-a)%360
-    else
-      nil
-    end
+    (360 - a) % 360 if a
   end
 
   # modifies @pb with any applied rotation
   def apply_rotate!
-    a = angle()
+    a = angle
 
-    unless (a%360).zero?
-      @pb = @pb.rotate(a)
-    end
+    @pb = @pb.rotate(a) unless (a % 360).zero?
 
     unless options['straighten'].to_f.zero?
       @pb = Morandi::Straighten.new(options['straighten'].to_f).call(nil, @pb)
@@ -167,41 +179,36 @@ protected
 
   DEFAULT_CONFIG = {
     'border-size-mm' => 5
-  }
+  }.freeze
+
   def config_for(key)
-    return options[key] if options && options.has_key?(key)
-    return @config[key] if @config && @config.has_key?(key)
+    return options[key] if options && options.key?(key)
+    return @config[key] if @config && @config.key?(key)
     DEFAULT_CONFIG[key]
   end
 
-  #
   def apply_crop!
     crop = options['crop']
 
-    if crop.nil? && config_for('image.auto-crop').eql?(false)
-      return
-    end
+    return if crop.nil? && config_for('image.auto-crop').eql?(false)
 
     if crop.is_a?(String) && crop =~ /^\d+,\d+,\d+,\d+/
       crop = crop.split(/,/).map(&:to_i)
     end
 
-    crop = nil unless crop.is_a?(Array) && crop.size.eql?(4) && crop.all? { |i|
-      i.kind_of?(Numeric)
-    }
+    crop = nil unless crop.is_a?(Array) && crop.size.eql?(4) && crop.all? do |i|
+      i.is_a?(Numeric)
+    end
 
     # can't crop, won't crop
     return if @width.nil? && @height.nil? && crop.nil?
 
-    if crop && @scale != 1.0
-      crop = crop.map { |s| (s.to_f * @scale).floor  }
-    end
+    crop = crop.map { |s| (s.to_f * @scale).floor } if crop && @scale != 1.0
 
     crop ||= Morandi::Utils.autocrop_coords(@pb.width, @pb.height, @width, @height)
 
     @pb = Morandi::Utils.apply_crop(@pb, crop[0], crop[1], crop[2], crop[3])
   end
-
 
   def apply_filters!
     filter = options['fx']
@@ -219,27 +226,26 @@ protected
   end
 
   def apply_decorations!
-    style, colour = options['border-style'], options['background-style']
+    style = options['border-style']
+    colour = options['background-style']
 
-    return if style.nil? or style.eql?('none')
+    return if style.nil? || style.eql?('none')
     return if colour.eql?('none')
     colour ||= 'black'
 
     crop = options['crop']
-    crop = crop.map { |s| (s.to_f * @scale).floor  } if crop && @scale != 1.0
+    crop = crop.map { |s| (s.to_f * @scale).floor } if crop && @scale != 1.0
 
-    op = Morandi::ImageBorder.new_from_hash(data={
-      'style' => style,
-      'colour' => colour || '#000000',
-      'crop' => crop,
-      'size' => [@image_width, @image_height],
-      'print_size' => [@width, @height],
-      'shrink'  => true,
-      'border_size' => @scale * config_for('border-size-mm').to_i * 300 / 25.4 # 5mm at 300dpi
-    })
+    op = Morandi::ImageBorder.new_from_hash(data = {
+                                              'style' => style,
+                                              'colour' => colour || '#000000',
+                                              'crop' => crop,
+                                              'size' => [@image_width, @image_height],
+                                              'print_size' => [@width, @height],
+                                              'shrink' => true,
+                                              'border_size' => @scale * config_for('border-size-mm').to_i * 300 / 25.4 # 5mm at 300dpi
+                                            })
 
     @pb = op.call(nil, @pb)
   end
-
 end
-

--- a/lib/morandi/profiled_pixbuf.rb
+++ b/lib/morandi/profiled_pixbuf.rb
@@ -1,11 +1,11 @@
 require 'gdk_pixbuf2'
 
-class Morandi::ProfiledPixbuf < Gdk::Pixbuf
+class Morandi::ProfiledPixbuf < GdkPixbuf::Pixbuf
   def valid_jpeg?(filename)
     return false unless File.exist?(filename)
     return false unless File.size(filename) > 0
 
-    type, _, _ = Gdk::Pixbuf.get_file_info(filename)
+    type, = GdkPixbuf::Pixbuf.get_file_info(filename)
 
     type && type.name.eql?('jpeg')
   rescue
@@ -16,26 +16,26 @@ class Morandi::ProfiledPixbuf < Gdk::Pixbuf
     "#{path}.icc.jpg"
   end
 
-  def initialize(*args)
-    @local_options = args.last.is_a?(Hash) && args.pop || {}
+  def initialize(options, local_options = {})
+    @local_options = local_options || {}
 
-    if args[0].is_a?(String)
-      @file = args[0]
+    if options[:file]
+      @file = options[:file]
 
       if suitable_for_jpegicc?
         icc_file = icc_cache_path
 
-        args[0] = icc_file if valid_jpeg?(icc_file) || system("jpgicc", "-q97", @file, icc_file)
+        options[:file] = icc_file if valid_jpeg?(icc_file) || system('jpgicc', '-q97', @file, icc_file)
       end
     end
 
-    super(*args)
+    super(options)
   end
 
-
   protected
+
   def suitable_for_jpegicc?
-    type, _, _ = Gdk::Pixbuf.get_file_info(@file)
+    type, = GdkPixbuf::Pixbuf.get_file_info(@file)
 
     type && type.name.eql?('jpeg')
   end

--- a/lib/morandi/redeye.rb
+++ b/lib/morandi/redeye.rb
@@ -1,39 +1,40 @@
 require 'redeye'
 
 module Morandi
-module RedEye
-module TapRedEye
-  module_function
-  def tap_on(pb, x, y)
-    n = ([pb.height,pb.width].max / 10)
-    x1  = [x - n, 0].max
-    x2  = [x + n, pb.width].min
-    y1  = [y - n, 0].max
-    y2  = [y + n, pb.height].min
-    return pb unless (x1 >= 0) && (x2 > x1) && (y1 >= 0) && (y2 > y1)
-    redeye = ::RedEye.new(pb, x1, y1, x2, y2)
+  module RedEye
+    module TapRedEye
+      module_function
 
-    sensitivity = 2
-    blobs = redeye.identify_blobs(sensitivity).reject { |i|
-      i.noPixels < 4 or ! i.squareish?(0.5, 0.4)
-    }.sort_by { |i|
-      i.area_min_x = x1
-      i.area_min_y = y1
+      def tap_on(pb, x, y)
+        n = ([pb.height, pb.width].max / 10)
+        x1  = [x - n, 0].max
+        x2  = [x + n, pb.width].min
+        y1  = [y - n, 0].max
+        y2  = [y + n, pb.height].min
+        return pb unless (x1 >= 0) && (x2 > x1) && (y1 >= 0) && (y2 > y1)
+        redeye = ::RedEye.new(pb, x1, y1, x2, y2)
 
-      # Higher is better
-      score = (i.noPixels) / (i.distance_from(x, y) ** 2)
-    }
+        sensitivity = 2
+        blobs = redeye.identify_blobs(sensitivity).reject do |i|
+          i.noPixels < 4 || !i.squareish?(0.5, 0.4)
+        end.sort_by do |i|
+          i.area_min_x = x1
+          i.area_min_y = y1
 
-    #blobs.each do |blob|
-    #  p [ [x, y], blob.centre(), blob.distance_from(x, y), blob]
-    #end
+          # Higher is better
+          score = i.noPixels / (i.distance_from(x, y)**2)
+        end
 
-    blob = blobs.last
-    redeye.correct_blob(blob.id) if blob
-    pb = redeye.pixbuf
+        # blobs.each do |blob|
+        #  p [ [x, y], blob.centre(), blob.distance_from(x, y), blob]
+        # end
+
+        blob = blobs.last
+        redeye.correct_blob(blob.id) if blob
+        pb = redeye.pixbuf
+      end
+    end
   end
-end
-end
 end
 
 class ::RedEye::Region
@@ -45,13 +46,12 @@ class ::RedEye::Region
   end
 
   # Pythagorean
-  def distance_from(x,y)
-    cx,cy = centre()
+  def distance_from(x, y)
+    cx, cy = centre
 
     dx = cx - x
     dy = cy - y
 
-    Math.sqrt( (dx * dx) + (dy * dy) )
+    Math.sqrt((dx * dx) + (dy * dy))
   end
 end
-

--- a/lib/morandi/utils.rb
+++ b/lib/morandi/utils.rb
@@ -1,6 +1,8 @@
 module Morandi
+  # Misc utility functions
   module Utils
     module_function
+
     def autocrop_coords(iw, ih, width, height)
       return nil unless width
       aspect = width.to_f / height.to_f
@@ -25,14 +27,14 @@ module Morandi
       end
 
       [
-        ((iw - crop_width)>>1),
-        ((ih - crop_height)>>1),
+        ((iw - crop_width) >> 1),
+        ((ih - crop_height) >> 1),
         crop_width,
         crop_height
-      ].map { |i| i.to_i }
+      ].map(&:to_i)
     end
 
-    def constrain(val,min,max)
+    def constrain(val, min, max)
       if val < min
         min
       elsif val > max
@@ -43,29 +45,13 @@ module Morandi
     end
 
     def apply_crop(pixbuf, x, y, w, h, fill_col = 0xffffffff)
-      if (x < 0) or (y < 0) || ((x+w) > pixbuf.width) || ((y+h) > pixbuf.height)
-        #tw, th = [w-x,w].max, [h-y,h].max
-        base_pixbuf = Gdk::Pixbuf.new(Gdk::Pixbuf::ColorSpace::RGB, false, 8, w, h)
+      if (x < 0) || (y < 0) || ((x + w) > pixbuf.width) || ((y + h) > pixbuf.height)
+        base_pixbuf = GdkPixbuf::Pixbuf.new(GdkPixbuf::Pixbuf::ColorSpace::RGB,
+                                            false, 8, w, h)
         base_pixbuf.fill!(fill_col)
-        dest_x = [x, 0].min
-        dest_y = [y, 0].min
-        #src_x = [x,0].max
-        #src_y = [y,0].max
-        dest_x = [-x,0].max
-        dest_y = [-y,0].max
 
-        #if x < 0
-        #else
-        #end
-        #if y < 0
-        #  dest_h = [h-dest_y, pixbuf.height, base_pixbuf.height-dest_y].min
-        #else
-        #	dest_h = [h,pixbuf.height].min
-        #end
-        #  dest_w  = [w-dest_x, pixbuf.width, base_pixbuf.width-dest_x].min
-
-        offset_x = [x,0].max
-        offset_y = [y,0].max
+        offset_x = [x, 0].max
+        offset_y = [y, 0].max
         copy_w = [w, pixbuf.width - offset_x].min
         copy_h = [h, pixbuf.height - offset_y].min
 
@@ -79,8 +65,10 @@ module Morandi
           copy_h = base_pixbuf.height - paste_y
         end
 
-        args = [pixbuf, paste_x, paste_y, copy_w, copy_h, paste_x - offset_x, paste_y - offset_y, 1, 1, Gdk::Pixbuf::INTERP_HYPER, 255]
-        #p args
+        args = [pixbuf, paste_x, paste_y, copy_w, copy_h,
+                paste_x - offset_x, paste_y - offset_y, 1, 1,
+                GdkPixbuf::Pixbuf::INTERP_HYPER, 255]
+
         base_pixbuf.composite!(*args)
         pixbuf = base_pixbuf
       else
@@ -88,30 +76,37 @@ module Morandi
         y = constrain(y, 0, pixbuf.height)
         w = constrain(w, 1, pixbuf.width - x)
         h = constrain(h, 1, pixbuf.height - y)
-        #p [pixbuf, x, y, w, h]
-        pixbuf = Gdk::Pixbuf.new(pixbuf, x, y, w, h)
+
+
+        pixbuf = pixbuf.new_subpixbuf(x, y, w, h)
       end
       pixbuf
     end
   end
 end
 
-class Gdk::Pixbuf
-  def scale_max(max_size, interp = Gdk::Pixbuf::InterpType::BILINEAR, max_scale = 1.0)
-    mul = (max_size / [width,height].max.to_f)
-    mul = [max_scale = 1.0,mul].min
-    scale(width * mul, height * mul, interp)
+module GdkPixbuf
+  # Extend GdkPixbuf::Pixbuf
+  class Pixbuf
+    def scale_max(max_size, interp = GdkPixbuf::InterpType::BILINEAR,
+                  max_scale = 1.0)
+      mul = (max_size / [width, height].max.to_f)
+      mul = [max_scale, mul].min
+      scale(width * mul, height * mul, interp)
+    end
   end
 end
 
-class Cairo::ImageSurface
-  def to_pixbuf
-    loader = Gdk::PixbufLoader.new
-    io = StringIO.new
-    write_to_png(io)
-    io.rewind
-    loader.last_write(io.read)
-    loader.pixbuf
+module Cairo
+  # Extend Cairo::ImageSurface
+  class ImageSurface
+    def to_pixbuf
+      loader = GdkPixbuf::PixbufLoader.new
+      io = StringIO.new
+      write_to_png(io)
+      io.rewind
+      loader.last_write(io.read)
+      loader.pixbuf
+    end
   end
 end
-

--- a/lib/morandi/version.rb
+++ b/lib/morandi/version.rb
@@ -1,3 +1,3 @@
 module Morandi
-  VERSION = "0.10.2"
+  VERSION = '0.11.0'.freeze
 end

--- a/morandi.gemspec
+++ b/morandi.gemspec
@@ -4,29 +4,29 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'morandi/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "morandi"
+  spec.name          = 'morandi'
   spec.version       = Morandi::VERSION
   spec.authors       = ["Geoff Youngs\n\n\n"]
-  spec.email         = ["git@intersect-uk.co.uk"]
-  spec.summary       = %q{Simple Image Edits}
-  spec.description   = %q{Apply simple edits to images}
-  spec.homepage      = ""
-  spec.license       = "MIT"
+  spec.email         = ['git@intersect-uk.co.uk']
+  spec.summary       = 'Simple Image Edits'
+  spec.description   = 'Apply simple edits to images'
+  spec.homepage      = ''
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_dependency "gtk2"
-  spec.add_dependency "gdk_pixbuf2"
-  spec.add_dependency "cairo"
-  spec.add_dependency "pixbufutils"
-  spec.add_dependency "redeye"
-  spec.add_dependency "pango"
-  spec.add_dependency "colorscore"
+  spec.add_dependency 'gtk2', '>= 3.0.9'
+  spec.add_dependency 'gdk_pixbuf2', '>= 3.0.9'
+  spec.add_dependency 'cairo'
+  spec.add_dependency 'pixbufutils'
+  spec.add_dependency 'redeye'
+  spec.add_dependency 'pango'
+  spec.add_dependency 'colorscore'
 
-  spec.add_development_dependency "bundler", "~> 1.5"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency 'bundler', '~> 1.5'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
 end

--- a/spec/morandi_spec.rb
+++ b/spec/morandi_spec.rb
@@ -1,119 +1,131 @@
 require 'morandi'
 
-RSpec.describe Morandi, "#process_to_file" do
-  context "in command mode" do
-    it "should create ouptut" do
-      Morandi.process("sample/sample.jpg", {}, out="sample/out_plain.jpg")
+RSpec.describe Morandi, '#process_to_file' do
+  context 'in command mode' do
+    it 'should create ouptut' do
+      Morandi.process('sample/sample.jpg', {}, out = 'sample/out_plain.jpg')
       expect(File.exist?(out))
     end
 
-    it "should do rotation of images" do
-      original = Gdk::Pixbuf.get_file_info("sample/sample.jpg")
-      Morandi.process("sample/sample.jpg", {
-        'angle' => 90
-      }, out="sample/out_rotate90.jpg")
+    it 'should do rotation of images' do
+      original = GdkPixbuf::Pixbuf.get_file_info('sample/sample.jpg')
+      Morandi.process('sample/sample.jpg', {
+                        'angle' => 90
+                      }, out = 'sample/out_rotate90.jpg')
       expect(File.exist?(out))
-      _,w,h = Gdk::Pixbuf.get_file_info(out)
+      _, w, h = GdkPixbuf::Pixbuf.get_file_info(out)
       expect(original[1]).to eq(h)
       expect(original[2]).to eq(w)
     end
 
-    it "should accept pixbufs as an argument" do
-      pixbuf = Gdk::Pixbuf.new("sample/sample.jpg")
+    it 'should accept pixbufs as an argument' do
+      pixbuf = GdkPixbuf::Pixbuf.new(file: 'sample/sample.jpg')
       pro = Morandi::ImageProcessor.new(pixbuf, {}, {})
       pro.process!
       expect(pixbuf.width).to eq(pro.result.width)
     end
 
-    it "should do cropping of images" do
-      Morandi.process("sample/sample.jpg", {
-        'crop' => [10,10,300,300]
-      }, out="sample/out_crop.jpg")
+    it 'should do cropping of images' do
+      Morandi.process('sample/sample.jpg', {
+                        'crop' => [10, 10, 300, 300]
+                      }, out = 'sample/out_crop.jpg')
       expect(File.exist?(out))
-      _,w,h = Gdk::Pixbuf.get_file_info(out)
+      _, w, h = GdkPixbuf::Pixbuf.get_file_info(out)
       expect(w).to eq(300)
       expect(h).to eq(300)
     end
 
-    it "should use user supplied path.icc" do
+    it 'should use user supplied path.icc' do
       src = 'sample/sample.jpg'
       icc = '/tmp/this-is-secure-thing.jpg'
       default_icc = Morandi::ImageProcessor.default_icc_path(src)
       out = 'sample/out_icc.jpg'
-      File.unlink(default_icc) rescue nil
-      Morandi.process(src, { }, out, { 'path.icc' => icc })
+      begin
+        File.unlink(default_icc)
+      rescue
+        nil
+      end
+      Morandi.process(src, {}, out, 'path.icc' => icc)
       expect(File).to exist(icc)
       expect(File).not_to exist(default_icc)
     end
 
-    it "should ignore user supplied path.icc" do
+    it 'should ignore user supplied path.icc' do
       src = 'sample/sample.jpg'
       icc = '/tmp/this-is-insecure-thing.jpg'
       default_icc = Morandi::ImageProcessor.default_icc_path(src)
-      File.unlink(icc) rescue 0
-      File.unlink(default_icc) rescue 0
+      begin
+        File.unlink(icc)
+      rescue
+        0
+      end
+      begin
+        File.unlink(default_icc)
+      rescue
+        0
+      end
       out = 'sample/out_icc.jpg'
       Morandi.process(src, { 'path.icc' => icc, 'output.max' => 200 }, out)
       expect(File).not_to exist(icc)
       expect(File).to exist(default_icc)
     end
 
-    it "should do cropping of images with a string" do
-      Morandi.process("sample/sample.jpg", {
-        'crop' => "10,10,300,300"
-      }, out="sample/out_crop.jpg")
+    it 'should do cropping of images with a string' do
+      Morandi.process('sample/sample.jpg', {
+                        'crop' => '10,10,300,300'
+                      }, out = 'sample/out_crop.jpg')
       expect(File.exist?(out))
-      _,w,h = Gdk::Pixbuf.get_file_info(out)
+      _, w, h = GdkPixbuf::Pixbuf.get_file_info(out)
       expect(w).to eq(300)
       expect(h).to eq(300)
     end
 
-    it "should reduce the size of images" do
-      Morandi.process("sample/sample.jpg", {
-        'output.max' => 200
-      }, out="sample/out_reduce.jpg")
+    it 'should reduce the size of images' do
+      Morandi.process('sample/sample.jpg', {
+                        'output.max' => 200
+                      }, out = 'sample/out_reduce.jpg')
       expect(File.exist?(out))
-      _,w,h = Gdk::Pixbuf.get_file_info(out)
+      _, w, h = GdkPixbuf::Pixbuf.get_file_info(out)
       expect(w).to be <= 200
       expect(h).to be <= 200
     end
 
-    it "should reduce the straighten images" do
-      Morandi.process("sample/sample.jpg", {
-        'straighten' => 5
-      }, out="sample/out_straighten.jpg")
+    it 'should reduce the straighten images' do
+      Morandi.process('sample/sample.jpg', {
+                        'straighten' => 5
+                      }, out = 'sample/out_straighten.jpg')
       expect(File.exist?(out))
-      _,w,h = Gdk::Pixbuf.get_file_info(out)
+      _, w, h = GdkPixbuf::Pixbuf.get_file_info(out)
       expect(_.name).to eq('jpeg')
     end
 
-    it "should reduce the gamma correct images" do
-      Morandi.process("sample/sample.jpg", {
-        'gamma' => 1.2
-      }, out="sample/out_gamma.jpg")
+    it 'should reduce the gamma correct images' do
+      Morandi.process('sample/sample.jpg', {
+                        'gamma' => 1.2
+                      }, out = 'sample/out_gamma.jpg')
       expect(File.exist?(out))
-      _,w,h = Gdk::Pixbuf.get_file_info(out)
+      _, w, h = GdkPixbuf::Pixbuf.get_file_info(out)
       expect(_.name).to eq('jpeg')
     end
 
-    it "should reduce the size of images" do
-      Morandi.process("sample/sample.jpg", {
-        'fx' => 'sepia'
-      }, out="sample/out_sepia.jpg")
+    it 'should reduce the size of images' do
+      Morandi.process('sample/sample.jpg', {
+                        'fx' => 'sepia'
+                      }, out = 'sample/out_sepia.jpg')
       expect(File.exist?(out))
-      _,w,h = Gdk::Pixbuf.get_file_info(out)
+      _, w, h = GdkPixbuf::Pixbuf.get_file_info(out)
       expect(_.name).to eq('jpeg')
     end
 
-    it "should output at the specified size" do
-      Morandi.process("sample/sample.jpg", {
-        'output.width' => 300,
-        'output.height' => 200,
-        'image.auto-crop' => true,
-        'output.limit' => true
-      }, out="sample/out_at_size.jpg")
+    it 'should output at the specified size' do
+      Morandi.process('sample/sample.jpg', {
+                        'output.width' => 300,
+                        'output.height' => 200,
+                        'image.auto-crop' => true,
+                        'output.limit' => true
+                      }, out = 'sample/out_at_size.jpg')
       expect(File.exist?(out))
-      _,w,h = Gdk::Pixbuf.get_file_info(out)
+      _, w, h = GdkPixbuf::Pixbuf.get_file_info(out)
       expect(_.name).to eq('jpeg')
       expect(h).to be <= 200
       expect(w).to be <= 300


### PR DESCRIPTION
Add support for the gobject introspection based Gdk::Pixbuf bindings that have a significantly different API.