### PR TITLE
#103953 adjust the red area density threshold to lower the risk of non removed red eyes in the final render

### DIFF
--- a/lib/morandi/image-ops.rb
+++ b/lib/morandi/image-ops.rb
@@ -263,35 +263,6 @@ class Gamma < ImageOp
   end
 end
 
-class RedEyeOp < ImageOp
-  attr_reader :x1, :y1, :x2, :y2, :sensitivity, :no_eyes
-  attr_accessor :order
-  def initialize(x1, y1, x2, y2, sensitivity, no_eyes)
-    super()
-    require 'redeye'
-    x1, x2 = x2, x1 if x1 > x2
-    y1, y2 = y2, y1 if y1 > y2
-    @x1, @y1, @x2, @y2, @sensitivity, @no_eyes =
-      x1, y1, x2, y2, sensitivity, no_eyes
-  end
-  def call(image, pixbuf)
-    @x2 = pixbuf.width if @x2 >= pixbuf.width
-    @y2 = pixbuf.height if @y2 >= pixbuf.height
-    @x1 = @x2 - 1 if @x1 >= @x2
-    @y1 = @y2 - 1 if @y1 >= @y2
-    redeye = ::RedEye.new(pixbuf.dup, @x1, @y1, @x2, @y2)
-    blobs = redeye.identify_blobs(@sensitivity).reject { |i|
-      i.noPixels < 2 or ! i.squareish?(0.5, 0.4)
-    }.sort_by { |i| i.noPixels }
-    biggest = blobs.size > @no_eyes ?  blobs[-1 * @no_eyes..-1] : blobs
-    biggest.each { |blob| redeye.correct_blob(blob.id) }
-    redeye.pixbuf
-  end
-  def priority
-    20 + @order
-  end
-end
-
 class Colourify < ImageOp
   attr_reader :op
   def initialize(op, alpha=255)

--- a/lib/morandi/redeye.rb
+++ b/lib/morandi/redeye.rb
@@ -5,7 +5,7 @@ module Morandi
     # The parameter determines how many reddish pixels needs to be in the area to consider it a valid red eye
     # The reason for its existence is to prevent the situations when the bigger red area causes an excessive correction
     # e.g. continuous red eyeglasses frame or sunburnt person's skin around eyes forming an area
-    RED_AREA_DENSITY_THRESHOLD = 0.4
+    RED_AREA_DENSITY_THRESHOLD = 0.3
   end
 end
 

--- a/lib/morandi/version.rb
+++ b/lib/morandi/version.rb
@@ -1,3 +1,3 @@
 module Morandi
-  VERSION = "0.10.2"
+  VERSION = '0.10.3'.freeze
 end


### PR DESCRIPTION
- Remove the unused `RedEyeOp` class
- Lower the density threshold required for detecting the region as a red eye (+ some tidy up around)
- Bump the gem version for the quick release