### PR TITLE
#104324 Add option to set the JPEG compression ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## Last updated 07.12.2018
+
+## [0.11.0] 07.12.2018
+### Added
+- Added option to set the JPEG image compression size [104324]

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ crop         | Array[Integer,Integer,Integer,Integer] | Crop image
 fx           | String greyscale,sepia,bluetone | Apply colour filters
 border-style  | String square,retro | Set border style
 background-style  | String retro,black,white | Set border colour
-
+quality       | Integer 1..100 | Set JPG compression value, defaults to 97%
 
 ## Contributing
 

--- a/lib/morandi.rb
+++ b/lib/morandi.rb
@@ -18,4 +18,3 @@ module Morandi
     pro.write_to_jpeg(out_file)
   end
 end
-

--- a/lib/morandi/image_processor.rb
+++ b/lib/morandi/image_processor.rb
@@ -71,8 +71,9 @@ class Morandi::ImageProcessor
     pb.save(fn, 'png')
   end
 
-  def write_to_jpeg(fn, quality = 97)
-    @pb.save(fn, 'jpeg', :quality => quality)
+  def write_to_jpeg(fn, quality = nil)
+    quality ||= options.fetch(:quality, 97)
+    @pb.save(fn, 'jpeg', quality: quality)
   end
 
 protected
@@ -242,4 +243,3 @@ protected
   end
 
 end
-

--- a/lib/morandi/image_processor.rb
+++ b/lib/morandi/image_processor.rb
@@ -72,11 +72,7 @@ class Morandi::ImageProcessor
   end
 
   def write_to_jpeg(fn, quality = nil)
-<<<<<<< HEAD
     quality ||= options.fetch(:quality, 97)
-=======
-    quality ||= options.fetch(:quality, 80)
->>>>>>> 07a25d9ef41e7afdd6977835a54a496f7fa1cac2
     @pb.save(fn, 'jpeg', quality: quality)
   end
 

--- a/lib/morandi/version.rb
+++ b/lib/morandi/version.rb
@@ -1,7 +1,3 @@
 module Morandi
-<<<<<<< HEAD
   VERSION = '0.11.0'.freeze
-=======
-  VERSION = '0.10.4'.freeze
->>>>>>> 07a25d9ef41e7afdd6977835a54a496f7fa1cac2
 end

--- a/lib/morandi/version.rb
+++ b/lib/morandi/version.rb
@@ -1,3 +1,3 @@
 module Morandi
-  VERSION = '0.10.3'.freeze
+  VERSION = '0.11.0'.freeze
 end

--- a/morandi.gemspec
+++ b/morandi.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "gtk2"
+  spec.add_dependency "gtk2", "~> 3.0.7"
   spec.add_dependency "gdk_pixbuf2"
   spec.add_dependency "cairo"
   spec.add_dependency "pixbufutils"

--- a/morandi.gemspec
+++ b/morandi.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "gtk2", "~> 3.0.7"
+  spec.add_dependency "gtk2"
   spec.add_dependency "gdk_pixbuf2"
   spec.add_dependency "cairo"
   spec.add_dependency "pixbufutils"

--- a/spec/morandi_spec.rb
+++ b/spec/morandi_spec.rb
@@ -105,6 +105,29 @@ RSpec.describe Morandi, "#process_to_file" do
       expect(_.name).to eq('jpeg')
     end
 
+    context 'quality' do
+      let(:max_quality_file_size) do
+        Morandi.process("sample/sample.jpg", { quality: 100 }, out="sample/out-100.jpg")
+        File.size("sample/out-100.jpg")
+      end
+
+      let(:default_of_97_quality) do
+        Morandi.process("sample/sample.jpg", {}, out="sample/out-97.jpg")
+        File.size("sample/out-97.jpg")
+      end
+
+      let(:quality_of_40_by_options_args) do
+        Morandi.process("sample/sample.jpg", { quality: 40 }, out="sample/out-40.jpg")
+        File.size("sample/out-40.jpg")
+      end
+
+      # Sort the output files' sizes and expect them to match to quality order
+      it "it has increasing file sizes with increasing quality" do
+        expect([default_of_97_quality, max_quality_file_size, quality_of_40_by_options_args].sort).to
+          eq([quality_of_40_by_options_args, default_of_97_quality, max_quality_file_size])
+      end
+    end
+
     it "should output at the specified size" do
       Morandi.process("sample/sample.jpg", {
         'output.width' => 300,

--- a/spec/morandi_spec.rb
+++ b/spec/morandi_spec.rb
@@ -120,19 +120,19 @@ RSpec.describe Morandi, "#process" do
     end
   end
 
-  context 'process with increasing quality settings' do
+  context 'with increasing quality settings' do
     let(:max_quality_file_size) do
-      Morandi.process("sample/sample.jpg", { quality: 100 }, out="sample/out-100.jpg")
+      Morandi.process("sample/sample.jpg", { quality: 100 }, "sample/out-100.jpg")
       File.size("sample/out-100.jpg")
     end
 
     let(:default_of_97_quality) do
-      Morandi.process("sample/sample.jpg", {}, out="sample/out-97.jpg")
+      Morandi.process("sample/sample.jpg", {}, "sample/out-97.jpg")
       File.size("sample/out-97.jpg")
     end
 
     let(:quality_of_40_by_options_args) do
-      Morandi.process("sample/sample.jpg", { quality: 40 }, out="sample/out-40.jpg")
+      Morandi.process("sample/sample.jpg", { quality: 40 }, "sample/out-40.jpg")
       File.size("sample/out-40.jpg")
     end
 

--- a/spec/morandi_spec.rb
+++ b/spec/morandi_spec.rb
@@ -1,6 +1,6 @@
 require 'morandi'
 
-RSpec.describe Morandi, "#process_to_file" do
+RSpec.describe Morandi, "#process" do
   context "in command mode" do
     it "should create ouptut" do
       Morandi.process("sample/sample.jpg", {}, out="sample/out_plain.jpg")
@@ -105,29 +105,6 @@ RSpec.describe Morandi, "#process_to_file" do
       expect(_.name).to eq('jpeg')
     end
 
-    context 'quality' do
-      let(:max_quality_file_size) do
-        Morandi.process("sample/sample.jpg", { quality: 100 }, out="sample/out-100.jpg")
-        File.size("sample/out-100.jpg")
-      end
-
-      let(:default_of_97_quality) do
-        Morandi.process("sample/sample.jpg", {}, out="sample/out-97.jpg")
-        File.size("sample/out-97.jpg")
-      end
-
-      let(:quality_of_40_by_options_args) do
-        Morandi.process("sample/sample.jpg", { quality: 40 }, out="sample/out-40.jpg")
-        File.size("sample/out-40.jpg")
-      end
-
-      # Sort the output files' sizes and expect them to match to quality order
-      it "it has increasing file sizes with increasing quality" do
-        expect([default_of_97_quality, max_quality_file_size, quality_of_40_by_options_args].sort).to
-          eq([quality_of_40_by_options_args, default_of_97_quality, max_quality_file_size])
-      end
-    end
-
     it "should output at the specified size" do
       Morandi.process("sample/sample.jpg", {
         'output.width' => 300,
@@ -140,6 +117,29 @@ RSpec.describe Morandi, "#process_to_file" do
       expect(_.name).to eq('jpeg')
       expect(h).to be <= 200
       expect(w).to be <= 300
+    end
+  end
+
+  context 'process with increasing quality settings' do
+    let(:max_quality_file_size) do
+      Morandi.process("sample/sample.jpg", { quality: 100 }, out="sample/out-100.jpg")
+      File.size("sample/out-100.jpg")
+    end
+
+    let(:default_of_97_quality) do
+      Morandi.process("sample/sample.jpg", {}, out="sample/out-97.jpg")
+      File.size("sample/out-97.jpg")
+    end
+
+    let(:quality_of_40_by_options_args) do
+      Morandi.process("sample/sample.jpg", { quality: 40 }, out="sample/out-40.jpg")
+      File.size("sample/out-40.jpg")
+    end
+
+    # Sort the output files' sizes and expect them to match to quality order
+    it "creates files of increasing size" do
+      expect([default_of_97_quality, max_quality_file_size, quality_of_40_by_options_args].sort).to
+        eq([quality_of_40_by_options_args, default_of_97_quality, max_quality_file_size])
     end
   end
 end


### PR DESCRIPTION
Currently, we set the default jpeg compression size to 97% which is wasteful for web consumption. This PR brings it down to 80% which is in line with Google's image optimisation guidelines. This should reduce file sizes by 500%, without any discernable difference to the user.

Link to [guide](https://images.guide/)