### PR TITLE
TECH-7701 - Have option to set the JPEG image compression size be a string like all the other options.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.gem
 *.rbc
 .bundle
+.DS_Store
 .config
 .yardoc
 Gemfile.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.11.0] 07.12.2018
 ### Added
 - Added option to set the JPEG image compression size [104324]
+
+## [0.11.1] 21.02.2019
+### Added
+- Have option to set the JPEG image compression size be a string like all the other options. [TECH-7701]

--- a/lib/morandi/image_processor.rb
+++ b/lib/morandi/image_processor.rb
@@ -72,7 +72,7 @@ class Morandi::ImageProcessor
   end
 
   def write_to_jpeg(fn, quality = nil)
-    quality ||= options.fetch(:quality, 97)
+    quality ||= options.fetch('quality', 97)
     @pb.save(fn, 'jpeg', quality: quality)
   end
 

--- a/lib/morandi/version.rb
+++ b/lib/morandi/version.rb
@@ -1,3 +1,3 @@
 module Morandi
-  VERSION = '0.11.0'.freeze
+  VERSION = '0.11.1'.freeze
 end

--- a/spec/morandi_spec.rb
+++ b/spec/morandi_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Morandi, "#process" do
 
   context 'with increasing quality settings' do
     let(:max_quality_file_size) do
-      Morandi.process("sample/sample.jpg", { quality: 100 }, "sample/out-100.jpg")
+      Morandi.process("sample/sample.jpg", { 'quality' => 100 }, "sample/out-100.jpg")
       File.size("sample/out-100.jpg")
     end
 
@@ -132,7 +132,7 @@ RSpec.describe Morandi, "#process" do
     end
 
     let(:quality_of_40_by_options_args) do
-      Morandi.process("sample/sample.jpg", { quality: 40 }, "sample/out-40.jpg")
+      Morandi.process("sample/sample.jpg", { 'quality' => 40 }, "sample/out-40.jpg")
       File.size("sample/out-40.jpg")
     end
 


### PR DESCRIPTION
The `quality` option was expecting a symbol however all the other settings use string keys. This is confusing and a pain to cater for.


***

https://livelinktech.atlassian.net/browse/TECH-7701