### PR TITLE
TECH-7663 SOLUTION2: Render failing due to Gdk::PixbufError::CorruptImage (Unsupported marker type 0x64) errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.11.1] 21.02.2019
 ### Added
 - Have option to set the JPEG image compression size be a string like all the other options. [TECH-7701]
+- While throwing Gdk::PixbufError::CorruptImage in Morandi::ProfiledPixbuf#initialize try to recover the image by saving it to a tempfile and re-read. This operation should remove all wrong markers. [TECH-7663]

--- a/lib/morandi/profiled_pixbuf.rb
+++ b/lib/morandi/profiled_pixbuf.rb
@@ -12,6 +12,15 @@ class Morandi::ProfiledPixbuf < Gdk::Pixbuf
     false
   end
 
+  def self.from_string(string, loader: nil, chunk_size: 4096)
+    loader ||= Gdk::PixbufLoader.new
+    ((string.bytesize + chunk_size - 1) / chunk_size).times do |i|
+      loader.write(string.byteslice(i * chunk_size, chunk_size))
+    end
+    loader.close
+    loader.pixbuf
+  end
+
   def self.default_icc_path(path)
     "#{path}.icc.jpg"
   end
@@ -33,6 +42,7 @@ class Morandi::ProfiledPixbuf < Gdk::Pixbuf
   rescue Gdk::PixbufError::CorruptImage => e
     if args[0].is_a? String
       temp_path =  Tempfile.new.path
+      pixbuf = self.class.from_string(File.read(args[0]))
       pixbuf.save(temp_path, 'jpeg')
       args[0] = temp_path
       super(*args)

--- a/lib/morandi/profiled_pixbuf.rb
+++ b/lib/morandi/profiled_pixbuf.rb
@@ -30,6 +30,15 @@ class Morandi::ProfiledPixbuf < Gdk::Pixbuf
     end
 
     super(*args)
+  rescue Gdk::PixbufError::CorruptImage => e
+    if args[0].is_a? String
+      temp_path =  Tempfile.new.path
+      pixbuf.save(temp_path, 'jpeg')
+      args[0] = temp_path
+      super(*args)
+    else
+      throw e
+    end
   end
 
 

--- a/lib/morandi/profiled_pixbuf.rb
+++ b/lib/morandi/profiled_pixbuf.rb
@@ -40,12 +40,14 @@ class Morandi::ProfiledPixbuf < Gdk::Pixbuf
 
     super(*args)
   rescue Gdk::PixbufError::CorruptImage => e
-    if args[0].is_a? String
-      temp_path =  Tempfile.new.path
+    if args[0].is_a?(String) && defined? Tempfile
+      temp =  Tempfile.new
       pixbuf = self.class.from_string(File.read(args[0]))
-      pixbuf.save(temp_path, 'jpeg')
-      args[0] = temp_path
+      pixbuf.save(temp.path, 'jpeg')
+      args[0] = temp.path
       super(*args)
+      temp.close
+      temp.unlink
     else
       throw e
     end


### PR DESCRIPTION
Link:
https://livelinktech.atlassian.net/browse/TECH-7663

Alternative solution:
https://github.com/livelink/web-kiosk/pull/5276
Effect: same as linked photos in PR.
(see screens here: #5276)

While working on PR 5267 I discovered that saving corrupted image into a file using Pixbuf's method `save` fixes the image.