### PR TITLE
TECH-9065 Update Morandi to work with gdk_pixbuf 3.0.9+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Last updated 07.12.2018
+## Last updated 26.06.2019
+
+## [0.11.3] 26.06.2019
+### Fixed
+- Compatability with gdk_pixbuf v3.0.9+ [TECH-9065]
 
 ## [0.11.2] 21.02.2019
 ### Added

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ crop         | Array[Integer,Integer,Integer,Integer] | Crop image
 fx           | String greyscale,sepia,bluetone | Apply colour filters
 border-style  | String square,retro | Set border style
 background-style  | String retro,black,white | Set border colour
-quality       | Integer 1..100 | Set JPG compression value, defaults to 97%
+quality       | String '1'..'100' | Set JPG compression value, defaults to 97%
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ morandi-js.
 
 ## Installation
 
+Install `liblcms2-utils` to provide the `jpgicc` command used by `Morandi::ProfiledPixbuf`
+
 Add this line to your application's Gemfile:
 
     gem 'morandi'

--- a/lib/morandi/image_processor.rb
+++ b/lib/morandi/image_processor.rb
@@ -72,8 +72,8 @@ class Morandi::ImageProcessor
   end
 
   def write_to_jpeg(fn, quality = nil)
-    quality ||= options.fetch('quality', 97)
-    @pb.save(fn, 'jpeg', quality: quality)
+    quality ||= options.fetch('quality', '97')
+    @pb.save(fn, 'jpeg', quality: quality.to_s)
   end
 
 protected

--- a/lib/morandi/utils.rb
+++ b/lib/morandi/utils.rb
@@ -1,3 +1,5 @@
+require 'gdk_pixbuf2'
+
 module Morandi
   module Utils
     module_function
@@ -97,6 +99,10 @@ module Morandi
 end
 
 class Gdk::Pixbuf
+  unless defined?(::Gdk::Pixbuf::InterpType)
+    InterpType = GdkPixbuf::InterpType
+  end
+
   def scale_max(max_size, interp = Gdk::Pixbuf::InterpType::BILINEAR, max_scale = 1.0)
     mul = (max_size / [width,height].max.to_f)
     mul = [max_scale = 1.0,mul].min
@@ -114,4 +120,3 @@ class Cairo::ImageSurface
     loader.pixbuf
   end
 end
-

--- a/lib/morandi/version.rb
+++ b/lib/morandi/version.rb
@@ -1,3 +1,3 @@
 module Morandi
-  VERSION = '0.11.2'.freeze
+  VERSION = '0.11.3'.freeze
 end

--- a/spec/morandi_spec.rb
+++ b/spec/morandi_spec.rb
@@ -138,8 +138,8 @@ RSpec.describe Morandi, "#process" do
 
     # Sort the output files' sizes and expect them to match to quality order
     it "creates files of increasing size" do
-      expect([default_of_97_quality, max_quality_file_size, quality_of_40_by_options_args].sort).to
-        eq([quality_of_40_by_options_args, default_of_97_quality, max_quality_file_size])
+      created_file_sizes = [default_of_97_quality, max_quality_file_size, quality_of_40_by_options_args].sort
+      expect(created_file_sizes).to eq([quality_of_40_by_options_args, default_of_97_quality, max_quality_file_size])
     end
   end
 end


### PR DESCRIPTION
Similar to https://github.com/livelink/morandi-rb/pull/1 but is backwards compatible with gdk_pixbuf2 < 3.0.9 as well