### PR TITLE
831 - Add ability to Shrink-to-Fit an input image inside an output photo

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -27,7 +27,7 @@ Metrics/BlockLength:
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 180
+  Max: 185
 
 # Offense count: 6
 # Configuration parameters: IgnoredMethods.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,17 +22,21 @@ Metrics/AbcSize:
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.
 # IgnoredMethods: refine
 Metrics/BlockLength:
-  Max: 269
+  Max: 319
 
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 166
+  Max: 180
 
 # Offense count: 6
 # Configuration parameters: IgnoredMethods.
 Metrics/CyclomaticComplexity:
   Max: 17
+
+# Offense count: 6
+Metrics/LineLength:
+  Max: 145
 
 # Offense count: 10
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,7 +22,10 @@ Metrics/AbcSize:
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.
 # IgnoredMethods: refine
 Metrics/BlockLength:
-  Max: 319
+  # Max: 120
+  Exclude:
+    - 'spec/**/*'
+    - '*.gemspec'
 
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Last updated 16.12.2020
+## Last updated 2021-05-19
+
+## [0.14.0] 2021-05-19
+### Added
+- Shrink-to-Fit operation [TECH-13938 / Kbz 831]
 
 ## [0.13.0] 16.12.2020
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -36,11 +36,13 @@ contrast     | Integer -20..20  | Change image contrast
 sharpen      | Integer -5..5  | Sharpen / Blur (negative value)
 redeye       | Array[[Integer,Integer],...]  | Apply redeye correction at point
 angle        | Integer 0,90,180,270  | Rotate image
-crop         | Array[Integer,Integer,Integer,Integer] | Crop image
+crop         | Array[Integer,Integer,Integer,Integer] | Crop image¹
 fx           | String greyscale,sepia,bluetone | Apply colour filters
 border-style  | String square,retro | Set border style
 background-style  | String retro,black,white | Set border colour
 quality       | String '1'..'100' | Set JPG compression value, defaults to 97%
+
+*¹ Supplying a `crop` with a negative value for an origin co-ordinate (e.g. `[-50,0,480,640]`) will apply a full-sized Shrink-to-Fit operation to the photo.*
 
 ## Contributing
 

--- a/lib/morandi/image_ops.rb
+++ b/lib/morandi/image_ops.rb
@@ -329,9 +329,7 @@ module Morandi
     def call(_image, pixbuf)
       return unless shrink
 
-      shrink_x, shrink_y, _width, _height = crop
       output_width, output_height = print_size
-
       surface = Cairo::ImageSurface.new(:rgb24, output_width, output_height)
       cr = Cairo::Context.new(surface)
 
@@ -342,11 +340,10 @@ module Morandi
         cr.fill
       end
 
-      cr.translate(shrink_x.abs, shrink_y.abs)
       scale_by = largest_shrink_ratio(output_width, output_height, pixbuf.width, pixbuf.height)
       width_difference = output_width - (pixbuf.width * scale_by)
       height_difference = output_height - (pixbuf.height * scale_by)
-      cr.translate(width_difference/2, height_difference/2)
+      cr.translate(width_difference / 2, height_difference / 2)
       cr.scale(scale_by, scale_by)
       cr.set_source_pixbuf(pixbuf)
 
@@ -364,8 +361,6 @@ module Morandi
     def largest_shrink_ratio(print_width, print_height, image_width, image_height)
       proportional_width = print_width / image_width.to_f
       proportional_height = print_height / image_height.to_f
-
-      return 1 if proportional_height >= 1 && proportional_width >= 1
 
       options = { proportional_width => [(image_width * proportional_width).round, (image_height * proportional_width).round],
                   proportional_height => [(image_width * proportional_height).round, (image_height * proportional_height).round] }

--- a/lib/morandi/image_ops.rb
+++ b/lib/morandi/image_ops.rb
@@ -318,12 +318,12 @@ module Morandi
 
   class ShrinkToFit < ImageOp
     BACKGROUND_COLOUR = Cairo::Color::WHITE
-    
+
     attr_accessor :crop, :size, :print_size, :shrink
 
     def call(_image, pixbuf)
       return unless shrink
-      
+
       shrink_x, shrink_y, _width, _height = crop
       output_width, output_height = print_size
 

--- a/lib/morandi/image_ops.rb
+++ b/lib/morandi/image_ops.rb
@@ -351,6 +351,7 @@ module Morandi
       # Clean up
       cr.destroy
       surface.destroy
+
       final_pb
     end
 

--- a/lib/morandi/image_ops.rb
+++ b/lib/morandi/image_ops.rb
@@ -331,9 +331,6 @@ module Morandi
       surface = Cairo::ImageSurface.new(:rgb24, output_width, output_height)
       cr = Cairo::Context.new(surface)
 
-      height = 250
-      width = 180
-
       # Apply White background
       cr.save do
         cr.set_operator :source

--- a/lib/morandi/image_ops.rb
+++ b/lib/morandi/image_ops.rb
@@ -329,7 +329,7 @@ module Morandi
     def call(_image, pixbuf)
       return unless shrink
 
-      output_width, output_height = print_size
+      output_width, output_height = autorotated_print_size(pixbuf)
       surface = Cairo::ImageSurface.new(:rgb24, output_width, output_height)
       cr = Cairo::Context.new(surface)
 
@@ -357,6 +357,12 @@ module Morandi
     end
 
     private
+
+    def autorotated_print_size(pixbuf)
+      return print_size.reverse if pixbuf.width < pixbuf.height
+
+      print_size
+    end
 
     def largest_shrink_ratio(print_width, print_height, image_width, image_height)
       proportional_width = print_width / image_width.to_f

--- a/lib/morandi/image_ops.rb
+++ b/lib/morandi/image_ops.rb
@@ -344,6 +344,9 @@ module Morandi
 
       cr.translate(shrink_x.abs, shrink_y.abs)
       scale_by = largest_shrink_ratio(output_width, output_height, pixbuf.width, pixbuf.height)
+      width_difference = output_width - (pixbuf.width * scale_by)
+      height_difference = output_height - (pixbuf.height * scale_by)
+      cr.translate(width_difference/2, height_difference/2)
       cr.scale(scale_by, scale_by)
       cr.set_source_pixbuf(pixbuf)
 

--- a/lib/morandi/image_ops.rb
+++ b/lib/morandi/image_ops.rb
@@ -317,38 +317,34 @@ module Morandi
   end
 
   class ShrinkToFit < ImageOp
+    BACKGROUND_COLOUR = Cairo::Color::WHITE
+    
     attr_accessor :crop, :size, :print_size, :shrink
 
     def call(_image, pixbuf)
       return unless shrink
-
-      original_img_height = pixbuf.height # Original size
-      original_img_width = pixbuf.width # Original size
-
+      
       shrink_x, shrink_y, _width, _height = crop
       output_width, output_height = print_size
 
       surface = Cairo::ImageSurface.new(:rgb24, output_width, output_height)
       cr = Cairo::Context.new(surface)
 
-      # Apply White background
       cr.save do
         cr.set_operator :source
-        cr.set_source_rgb 1, 1, 1
+        cr.set_source_color BACKGROUND_COLOUR
         cr.paint
         cr.fill
       end
-      # end
 
       cr.translate(shrink_x.abs, shrink_y.abs)
-      scale_by = largest_shrink_ratio(output_width, output_height, original_img_width, original_img_height)
+      scale_by = largest_shrink_ratio(output_width, output_height, pixbuf.width, pixbuf.height)
       cr.scale(scale_by, scale_by)
       cr.set_source_pixbuf(pixbuf)
 
       cr.paint(1.0)
       final_pb = surface.to_pixbuf
 
-      # Clean up
       cr.destroy
       surface.destroy
 

--- a/lib/morandi/image_processor.rb
+++ b/lib/morandi/image_processor.rb
@@ -239,8 +239,6 @@ module Morandi
     def apply_shrink_to_fit!
       return unless negative_crop?
 
-      crop = options['crop']
-
       op = Morandi::ShrinkToFit.new_from_hash(
         'crop' => options['crop'],
         'print_size' => [@width, @height],
@@ -258,9 +256,9 @@ module Morandi
 
     def negative_crop?
       # Pretty sure this can be incorporated into the apply_crop! incase it comes as a string.
-      return unless crop = options['crop']
+      return unless options.has_key?('crop')
 
-      crop[0].to_i.negative? || crop[1].to_i.negative?
+      options['crop'][0].to_i.negative? || options['crop'][1].to_i.negative?
     end
   end
 end

--- a/lib/morandi/image_processor.rb
+++ b/lib/morandi/image_processor.rb
@@ -184,7 +184,7 @@ module Morandi
       return if @width.nil? && @height.nil? && crop.nil?
 
       if crop.nil?
-        crop ||= Morandi::Utils.autocrop_coords(@pb.width, @pb.height, @width, @height)
+        crop = Morandi::Utils.autocrop_coords(@pb.width, @pb.height, @width, @height)
       elsif not_equal_to_one(@scale)
         crop.map! { |s| (s.to_f * @scale).floor }
       end

--- a/lib/morandi/image_processor.rb
+++ b/lib/morandi/image_processor.rb
@@ -248,7 +248,7 @@ module Morandi
     end
 
     def unpack_crop_options
-      if options['crop'].is_a?(String) && crop =~ /^\d+,\d+,\d+,\d+/
+      if options['crop'].is_a?(String) && options['crop'] =~ /^\d+,\d+,\d+,\d+/
         options['crop'].split(/,/).map(&:to_i)
       elsif options['crop'].is_a?(Array) && options['crop'].length.eql?(4) && options['crop'].all? { |i| i.is_a?(Numeric) }
         options['crop']

--- a/lib/morandi/image_processor.rb
+++ b/lib/morandi/image_processor.rb
@@ -259,7 +259,7 @@ module Morandi
     def negative_crop?
       # Pretty sure this can be incorporated into the apply_crop! incase it comes as a string.
       return unless crop = options['crop']
-      
+
       crop[0].to_i.negative? || crop[1].to_i.negative?
     end
   end

--- a/lib/morandi/image_processor.rb
+++ b/lib/morandi/image_processor.rb
@@ -186,6 +186,8 @@ module Morandi
                Morandi::Utils.autocrop_coords(@pb.width, @pb.height, @width, @height)
              elsif not_equal_to_one(@scale)
                @crop.map { |s| (s.to_f * @scale).floor }
+             else
+               @crop
              end
 
       @pb = Morandi::Utils.apply_crop(@pb, crop[0], crop[1], crop[2], crop[3])

--- a/lib/morandi/image_processor.rb
+++ b/lib/morandi/image_processor.rb
@@ -53,7 +53,7 @@ module Morandi
       # add border
       apply_decorations!
 
-      # apply shrink to fit
+      # shrink to fit
       apply_shrink_to_fit!
 
       @pb = @pb.scale_max([@width, @height].max) if @options['output.limit'] && @width && @height
@@ -174,6 +174,8 @@ module Morandi
     end
 
     def apply_crop!
+      return if negative_crop?
+
       crop = options['crop']
 
       return if crop.nil? && config_for('image.auto-crop').eql?(false)
@@ -187,7 +189,8 @@ module Morandi
       # can't crop, won't crop
       return if @width.nil? && @height.nil? && crop.nil?
 
-      crop = [0, 0, crop[2], crop[3]] if negative_crop? # X and Y crops are 0 so the original image is still in tack for Shrink to fit.
+      crop = [0, 0, crop[2], crop[3]] if negative_crop?
+      # X and Y crops are 0 so the original image is still in tack for Shrink to fit.
 
       crop = crop.map { |s| (s.to_f * @scale).floor } if crop && not_equal_to_one(@scale)
 
@@ -236,11 +239,12 @@ module Morandi
     def apply_shrink_to_fit!
       return unless negative_crop?
 
+      crop = options['crop']
+
       op = Morandi::ShrinkToFit.new_from_hash(
         'crop' => options['crop'],
-        'size' => [@image_width, @image_height],
         'print_size' => [@width, @height],
-        'shrink' => true,
+        'shrink' => true
       )
 
       @pb = op.call(nil, @pb)
@@ -255,6 +259,7 @@ module Morandi
     def negative_crop?
       # Pretty sure this can be incorporated into the apply_crop! incase it comes as a string.
       return unless crop = options['crop']
+      
       crop[0].to_i.negative? || crop[1].to_i.negative?
     end
   end

--- a/lib/morandi/image_processor.rb
+++ b/lib/morandi/image_processor.rb
@@ -243,7 +243,7 @@ module Morandi
     end
 
     def unpack_crop_options
-      if options['crop'].is_a?(String) && options['crop'] =~ /^\d+,\d+,\d+,\d+/
+      if options['crop'].is_a?(String) && options['crop'] =~ /^-?\d+,-?\d+,\d+,\d+/
         options['crop'].split(/,/).map(&:to_i)
       elsif options['crop'].is_a?(Array) && options['crop'].length.eql?(4) && options['crop'].all? { |i| i.is_a?(Numeric) }
         options['crop']

--- a/lib/morandi/image_processor.rb
+++ b/lib/morandi/image_processor.rb
@@ -252,8 +252,6 @@ module Morandi
         options['crop'].split(/,/).map(&:to_i)
       elsif options['crop'].is_a?(Array) && options['crop'].length.eql?(4) && options['crop'].all? { |i| i.is_a?(Numeric) }
         options['crop']
-      else
-        nil
       end
     end
 

--- a/lib/morandi/image_processor.rb
+++ b/lib/morandi/image_processor.rb
@@ -231,7 +231,7 @@ module Morandi
       return unless negative_crop?
 
       op = Morandi::ShrinkToFit.new_from_hash(
-        'crop' => unpack_crop_options,
+        'crop' => @crop,
         'print_size' => [@width, @height],
         'shrink' => true
       )

--- a/lib/morandi/image_processor.rb
+++ b/lib/morandi/image_processor.rb
@@ -176,10 +176,7 @@ module Morandi
 
     def apply_crop!
       return if negative_crop?
-
       return if @crop.nil? && config_for('image.auto-crop').eql?(false)
-
-      # can't crop, won't crop
       return if @width.nil? && @height.nil? && @crop.nil?
 
       crop = if @crop.nil?
@@ -207,18 +204,16 @@ module Morandi
 
     def apply_decorations!
       style = options['border-style']
-      colour = options['background-style']
+      colour = options['background-style'] || 'black'
 
       return if style.nil? || style.eql?('none')
       return if colour.eql?('none')
-
-      colour ||= 'black'
 
       crop = @crop.map { |s| (s.to_f * @scale).floor } if @crop && not_equal_to_one(@scale)
 
       op = Morandi::ImageBorder.new_from_hash(
         'style' => style,
-        'colour' => colour || '#000000',
+        'colour' => colour,
         'crop' => crop,
         'size' => [@image_width, @image_height],
         'print_size' => [@width, @height],

--- a/lib/morandi/redeye.rb
+++ b/lib/morandi/redeye.rb
@@ -18,10 +18,10 @@ module Morandi
 
       def tap_on(pixbuf, x_coord, y_coord)
         n = ([pixbuf.height, pixbuf.width].max / 10)
-        x1  = [x_coord - n, 0].max
-        x2  = [x_coord + n, pixbuf.width].min
-        y1  = [y_coord - n, 0].max
-        y2  = [y_coord + n, pixbuf.height].min
+        x1 = [x_coord - n, 0].max
+        x2 = [x_coord + n, pixbuf.width].min
+        y1 = [y_coord - n, 0].max
+        y2 = [y_coord + n, pixbuf.height].min
         return pixbuf unless (x1 >= 0) && (x2 > x1) && (y1 >= 0) && (y2 > y1)
 
         redeye = ::RedEye.new(pixbuf, x1, y1, x2, y2)

--- a/lib/morandi/version.rb
+++ b/lib/morandi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Morandi
-  VERSION = '0.13.1'
+  VERSION = '0.14.0'
 end

--- a/spec/morandi_spec.rb
+++ b/spec/morandi_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Morandi, '#process' do
         Morandi.process(pixbuf, options, file_out)
       end
 
-      let(:pixbuf) { GdkPixbuf::Pixbuf.new(file_in) }
+      let(:pixbuf) { GdkPixbuf::Pixbuf.new(file: file_in) }
 
       it 'should process the file' do
         process_image

--- a/spec/morandi_spec.rb
+++ b/spec/morandi_spec.rb
@@ -323,7 +323,8 @@ RSpec.describe Morandi, '#process' do
 
     describe 'when given a print size of 400 by 325' do
       let(:options) do
-        { 'crop' => [10, -10, original_image_width, original_image_height],
+        {
+          'crop' => [10, -10, original_image_width, original_image_height],
           'output.width' => 400,
           'output.height' => 325
         }
@@ -339,9 +340,10 @@ RSpec.describe Morandi, '#process' do
       end
     end
 
-    describe 'when given a print size larger than the image' do 
+    describe 'when given a print size larger than the image' do
       let(:options) do
-        { 'crop' => [10, -10, original_image_width, original_image_height],
+        {
+          'crop' => [10, -10, original_image_width, original_image_height],
           'output.width' => 900,
           'output.height' => 700
         }
@@ -349,7 +351,7 @@ RSpec.describe Morandi, '#process' do
 
       it 'does not alter the image (though print size remains the same)' do
         process_image
-        
+
         expect(File).to exist(file_out)
         expect(processed_image_type).to eq('jpeg')
         expect(processed_image_width).to eq(900)
@@ -359,7 +361,8 @@ RSpec.describe Morandi, '#process' do
 
     describe 'when given an image with the same height as the print but still too wide' do
       let(:options) do
-        { 'crop' => [10, -10, original_image_width, original_image_height],
+        {
+          'crop' => [10, -10, original_image_width, original_image_height],
           'output.width' => 600,
           'output.height' => 650
         }
@@ -377,7 +380,8 @@ RSpec.describe Morandi, '#process' do
 
     describe 'when given an image with the same width as the print but still too tall' do
       let(:options) do
-        { 'crop' => [10, -10, original_image_width, original_image_height],
+        {
+          'crop' => [10, -10, original_image_width, original_image_height],
           'output.width' => 800,
           'output.height' => 600
         }

--- a/spec/morandi_spec.rb
+++ b/spec/morandi_spec.rb
@@ -252,7 +252,6 @@ RSpec.describe Morandi, '#process' do
     describe 'when applying a border and maintaining the original size' do
       let(:options) do
         {
-          'crop' => [10, -10, original_image_width, original_image_height],
           'border-style' => 'square',
           'background-style' => 'dominant',
           'border-size-mm' => 5,
@@ -309,7 +308,7 @@ RSpec.describe Morandi, '#process' do
       {
         'crop' => [0, -172.9338582677165, cropped_width, cropped_height],
         'output.width' => cropped_width,
-        'output.height' => cropped_height
+        'output.height' => cropped_height,
       }
     end
 
@@ -318,20 +317,14 @@ RSpec.describe Morandi, '#process' do
 
       expect(File).to exist(file_out)
       expect(processed_image_type).to eq('jpeg')
-      expect(processed_image_width).to eq(original_image_width)
-      expect(processed_image_height).to eq(original_image_height)
+      expect(processed_image_width).to eq(cropped_width)
+      expect(processed_image_height).to eq(cropped_height)
     end
 
     it 'should when given a print size of 400 by 325 half the size of the input image' do
-      let(:options) do
-        {
-          'crop' => [10, -10, original_image_width, original_image_height],
-          'output.width' => 400,
-          'output.height' => 325
-        }
-      end
+      shrink_to_fit_options = { 'crop' => [10, -10, original_image_width, original_image_height], 'output.width' => 400, 'output.height' => 325 }
 
-      process_image
+      Morandi.process(file_in, shrink_to_fit_options, file_out)
 
       expect(File).to exist(file_out)
       expect(processed_image_type).to eq('jpeg')
@@ -339,33 +332,21 @@ RSpec.describe Morandi, '#process' do
       expect(processed_image_height).to eq(325)
     end
 
-    it 'when given a print size larger than the image not alter the image' do
-      let(:options) do
-        {
-          'crop' => [10, -10, original_image_width, original_image_height],
-          'output.width' => 900,
-          'output.height' => 700
-        }
-      end
+    it 'when given a print size larger than the image not alter the image but still have a larger output print' do
+      shrink_to_fit_options = { 'crop' => [10, -10, original_image_width, original_image_height], 'output.width' => 900, 'output.height' => 700 }
 
-      process_image
+      Morandi.process(file_in, shrink_to_fit_options, file_out)
 
       expect(File).to exist(file_out)
       expect(processed_image_type).to eq('jpeg')
-      expect(processed_image_width).to eq(original_image_width)
-      expect(processed_image_height).to eq(original_image_height)
+      expect(processed_image_width).to eq(900)
+      expect(processed_image_height).to eq(700)
     end
 
     it 'when given a print size that has a smaller width still adjust the height to maintain the aspect ratio' do
-      let(:options) do
-        {
-          'crop' => [10, -10, original_image_width, original_image_height],
-          'output.width' => 600,
-          'output.height' => 650
-        }
-      end
+      shrink_to_fit_options = { 'crop' => [10, -10, original_image_width, original_image_height], 'output.width' => 600, 'output.height' => 650 }
 
-      process_image
+      Morandi.process(file_in, shrink_to_fit_options, file_out)
 
       expect(File).to exist(file_out)
       expect(processed_image_type).to eq('jpeg')
@@ -374,15 +355,9 @@ RSpec.describe Morandi, '#process' do
     end
 
     it 'when given a print size that has a smaller height still adjust the width to maintain the aspect ratio' do
-      let(:options) do
-        {
-          'crop' => [10, -10, original_image_width, original_image_height],
-          'output.width' => 800,
-          'output.height' => 600
-        }
-      end
+      shrink_to_fit_options = { 'crop' => [10, -10, original_image_width, original_image_height], 'output.width' => 800, 'output.height' => 600 }
 
-      process_image
+      Morandi.process(file_in, shrink_to_fit_options, file_out)
 
       expect(File).to exist(file_out)
       expect(processed_image_type).to eq('jpeg')

--- a/spec/morandi_spec.rb
+++ b/spec/morandi_spec.rb
@@ -252,6 +252,7 @@ RSpec.describe Morandi, '#process' do
     describe 'when applying a border and maintaining the original size' do
       let(:options) do
         {
+          'crop' => [10, -10, original_image_width, original_image_height],
           'border-style' => 'square',
           'background-style' => 'dominant',
           'border-size-mm' => 5,
@@ -304,21 +305,11 @@ RSpec.describe Morandi, '#process' do
     let(:cropped_width) { 1767 }
     let(:cropped_height) { 1414 }
 
-    #   Example's of crops if it helps
-    # 	4x4 =   {"crop”:”0,-393.8, 1414, 1414"}
-    # 	4x6 =   {"crop”:”0, -31, 2121, 1414"}
-    #   8x10 =  {"crop”:”0, 172.9338582677165, 1767, 1414"}
-
-
-    
-  # let(:original_image_width) { 800 }
-  # let(:original_image_height) { 650 }
-
     let(:options) do
       {
         'crop' => [0, -172.9338582677165, cropped_width, cropped_height],
         'output.width' => cropped_width,
-        'output.height' => cropped_height,
+        'output.height' => cropped_height
       }
     end
 
@@ -327,14 +318,20 @@ RSpec.describe Morandi, '#process' do
 
       expect(File).to exist(file_out)
       expect(processed_image_type).to eq('jpeg')
-      expect(processed_image_width).to eq(cropped_width)
-      expect(processed_image_height).to eq(cropped_height)
+      expect(processed_image_width).to eq(original_image_width)
+      expect(processed_image_height).to eq(original_image_height)
     end
 
     it 'should when given a print size of 400 by 325 half the size of the input image' do
-      shrink_to_fit_options = { 'crop' => [10, -10, original_image_width, original_image_height], 'output.width' => 400, 'output.height' => 325 }
+      let(:options) do
+        {
+          'crop' => [10, -10, original_image_width, original_image_height],
+          'output.width' => 400,
+          'output.height' => 325
+        }
+      end
 
-      Morandi.process(file_in, shrink_to_fit_options, file_out)
+      process_image
 
       expect(File).to exist(file_out)
       expect(processed_image_type).to eq('jpeg')
@@ -342,21 +339,33 @@ RSpec.describe Morandi, '#process' do
       expect(processed_image_height).to eq(325)
     end
 
-    it 'when given a print size larger than the image not alter the image but still have a larger output print' do
-      shrink_to_fit_options = { 'crop' => [10, -10, original_image_width, original_image_height], 'output.width' => 900, 'output.height' => 700 }
+    it 'when given a print size larger than the image not alter the image' do
+      let(:options) do
+        {
+          'crop' => [10, -10, original_image_width, original_image_height],
+          'output.width' => 900,
+          'output.height' => 700
+        }
+      end
 
-      Morandi.process(file_in, shrink_to_fit_options, file_out)
+      process_image
 
       expect(File).to exist(file_out)
       expect(processed_image_type).to eq('jpeg')
-      expect(processed_image_width).to eq(900)
-      expect(processed_image_height).to eq(700)
+      expect(processed_image_width).to eq(original_image_width)
+      expect(processed_image_height).to eq(original_image_height)
     end
 
     it 'when given a print size that has a smaller width still adjust the height to maintain the aspect ratio' do
-      shrink_to_fit_options = { 'crop' => [10, -10, original_image_width, original_image_height], 'output.width' => 600, 'output.height' => 650 }
+      let(:options) do
+        {
+          'crop' => [10, -10, original_image_width, original_image_height],
+          'output.width' => 600,
+          'output.height' => 650
+        }
+      end
 
-      Morandi.process(file_in, shrink_to_fit_options, file_out)
+      process_image
 
       expect(File).to exist(file_out)
       expect(processed_image_type).to eq('jpeg')
@@ -365,9 +374,15 @@ RSpec.describe Morandi, '#process' do
     end
 
     it 'when given a print size that has a smaller height still adjust the width to maintain the aspect ratio' do
-      shrink_to_fit_options = { 'crop' => [10, -10, original_image_width, original_image_height], 'output.width' => 800, 'output.height' => 600 }
+      let(:options) do
+        {
+          'crop' => [10, -10, original_image_width, original_image_height],
+          'output.width' => 800,
+          'output.height' => 600
+        }
+      end
 
-      Morandi.process(file_in, shrink_to_fit_options, file_out)
+      process_image
 
       expect(File).to exist(file_out)
       expect(processed_image_type).to eq('jpeg')

--- a/spec/morandi_spec.rb
+++ b/spec/morandi_spec.rb
@@ -300,7 +300,7 @@ RSpec.describe Morandi, '#process' do
     end
   end
 
-  describe 'when applying shrink to fit' do
+  context 'when applying shrink to fit' do
     let(:cropped_width) { 1767 }
     let(:cropped_height) { 1414 }
 
@@ -321,48 +321,76 @@ RSpec.describe Morandi, '#process' do
       expect(processed_image_height).to eq(cropped_height)
     end
 
-    it 'should when given a print size of 400 by 325 half the size of the input image' do
-      shrink_to_fit_options = { 'crop' => [10, -10, original_image_width, original_image_height], 'output.width' => 400, 'output.height' => 325 }
+    describe 'when given a print size of 400 by 325' do
+      let(:options) do
+        { 'crop' => [10, -10, original_image_width, original_image_height],
+          'output.width' => 400,
+          'output.height' => 325
+        }
+      end
 
-      Morandi.process(file_in, shrink_to_fit_options, file_out)
+      it 'halves the size of the input image' do
+        process_image
 
-      expect(File).to exist(file_out)
-      expect(processed_image_type).to eq('jpeg')
-      expect(processed_image_width).to eq(400)
-      expect(processed_image_height).to eq(325)
+        expect(File).to exist(file_out)
+        expect(processed_image_type).to eq('jpeg')
+        expect(processed_image_width).to eq(400)
+        expect(processed_image_height).to eq(325)
+      end
     end
 
-    it 'when given a print size larger than the image not alter the image but still have a larger output print' do
-      shrink_to_fit_options = { 'crop' => [10, -10, original_image_width, original_image_height], 'output.width' => 900, 'output.height' => 700 }
+    describe 'when given a print size larger than the image' do 
+      let(:options) do
+        { 'crop' => [10, -10, original_image_width, original_image_height],
+          'output.width' => 900,
+          'output.height' => 700
+        }
+      end
 
-      Morandi.process(file_in, shrink_to_fit_options, file_out)
-
-      expect(File).to exist(file_out)
-      expect(processed_image_type).to eq('jpeg')
-      expect(processed_image_width).to eq(900)
-      expect(processed_image_height).to eq(700)
+      it 'does not alter the image (though print size remains the same)' do
+        process_image
+        
+        expect(File).to exist(file_out)
+        expect(processed_image_type).to eq('jpeg')
+        expect(processed_image_width).to eq(900)
+        expect(processed_image_height).to eq(700)
+      end
     end
 
-    it 'when given a print size that has a smaller width still adjust the height to maintain the aspect ratio' do
-      shrink_to_fit_options = { 'crop' => [10, -10, original_image_width, original_image_height], 'output.width' => 600, 'output.height' => 650 }
+    describe 'when given an image with the same height as the print but still too wide' do
+      let(:options) do
+        { 'crop' => [10, -10, original_image_width, original_image_height],
+          'output.width' => 600,
+          'output.height' => 650
+        }
+      end
 
-      Morandi.process(file_in, shrink_to_fit_options, file_out)
+      it 'shrinks the image by both width and height to maintain the ratio (print size remains the same)' do
+        process_image
 
-      expect(File).to exist(file_out)
-      expect(processed_image_type).to eq('jpeg')
-      expect(processed_image_width).to eq(600)
-      expect(processed_image_height).to eq(650)
+        expect(File).to exist(file_out)
+        expect(processed_image_type).to eq('jpeg')
+        expect(processed_image_width).to eq(600)
+        expect(processed_image_height).to eq(650)
+      end
     end
 
-    it 'when given a print size that has a smaller height still adjust the width to maintain the aspect ratio' do
-      shrink_to_fit_options = { 'crop' => [10, -10, original_image_width, original_image_height], 'output.width' => 800, 'output.height' => 600 }
+    describe 'when given an image with the same width as the print but still too tall' do
+      let(:options) do
+        { 'crop' => [10, -10, original_image_width, original_image_height],
+          'output.width' => 800,
+          'output.height' => 600
+        }
+      end
 
-      Morandi.process(file_in, shrink_to_fit_options, file_out)
+      it 'shrinks the image by both width and height to maintain the ratio (print size remains the same)' do
+        process_image
 
-      expect(File).to exist(file_out)
-      expect(processed_image_type).to eq('jpeg')
-      expect(processed_image_width).to eq(800)
-      expect(processed_image_height).to eq(600)
+        expect(File).to exist(file_out)
+        expect(processed_image_type).to eq('jpeg')
+        expect(processed_image_width).to eq(800)
+        expect(processed_image_height).to eq(600)
+      end
     end
   end
 

--- a/spec/morandi_spec.rb
+++ b/spec/morandi_spec.rb
@@ -308,7 +308,7 @@ RSpec.describe Morandi, '#process' do
       {
         'crop' => [0, -172.9338582677165, cropped_width, cropped_height],
         'output.width' => cropped_width,
-        'output.height' => cropped_height,
+        'output.height' => cropped_height
       }
     end
 


### PR DESCRIPTION
Implementing a Shrink to Fit class within Morandi and the applicable tests.
[TECH-13938 / Kbz 831](https://livelinktechnology.kanbanize.com/ctrl_board/6/cards/831/details/)

Does not alter the size of the print but will change the size of the image whilst maintaining the original image ratio to fit smaller prints. Images that are already smaller than the print borders are not affected.

As a result, if the image is not the same width to height ratio as the selected print size, you will end up with some blank space.

Examples of 10x8 prints of landscape, square and portrait (auto-rotated to a portrait output) images, that would otherwise have some content cropped to fill the print:

<kbd><img src="https://user-images.githubusercontent.com/193455/118865801-416cde80-b8d9-11eb-8cd5-3f7f70a3fa9c.png" width="200" /></kbd> · <kbd><img src="https://user-images.githubusercontent.com/193455/118865794-3f0a8480-b8d9-11eb-9fd6-db81441b6fb7.png" width="200" /></kbd> · <kbd><img src="https://user-images.githubusercontent.com/193455/118865797-3fa31b00-b8d9-11eb-94f4-63746f5bd360.png" height="133" /></kbd>