### PR TITLE
feat!: raise custom Morandi errors + tidy-up

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,9 @@ jobs:
     name: ensures the dev environment image builds
     steps:
       - name: checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: build container
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
           context: .
           file: ./Dockerfile
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: lint code with rubocop
         uses: andrewmcodes/rubocop-linter-action@v3.3.0
         env:
@@ -38,7 +38,7 @@ jobs:
         run: |
           sudo apt-get install -yqq liblcms2-utils libglib2.0-dev libgtk2.0-dev libgdk-pixbuf2.0-dev
       - name: checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: set up ruby environment
         uses: ruby/setup-ruby@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Extracted image operations to separate files within a dedicated module
+- [BREAKING] Introduced raising Morandi's own errors instead of bubbling Pixbuf's
 
 ## [0.99.03] 19.09.2024
 ### Added
@@ -19,8 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bumped version to 0.99.01 in preparation for a 1.0 release
 
 ### Removed
-- support for Ruby 2.0 (and illusion of it being tested by CI)
-- support for Ruby 2.3
+- [BREAKING] support for Ruby 2.0 (and illusion of it being tested by CI)
+- [BREAKING] support for Ruby 2.3
 - gtk2 dependency
 
 ## [0.13.0] 16.12.2020

--- a/lib/morandi.rb
+++ b/lib/morandi.rb
@@ -5,6 +5,7 @@ require 'morandi_native'
 
 require 'morandi/cairo_ext'
 require 'morandi/pixbuf_ext'
+require 'morandi/errors'
 require 'morandi/image_processor'
 require 'morandi/redeye'
 require 'morandi/crop_utils'

--- a/lib/morandi/errors.rb
+++ b/lib/morandi/errors.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Morandi
+  class Error < StandardError
+  end
+
+  class CorruptImageError < Error
+  end
+
+  class UnknownTypeError < Error
+  end
+end

--- a/lib/morandi/image_processor.rb
+++ b/lib/morandi/image_processor.rb
@@ -97,10 +97,10 @@ module Morandi
       # @scale = @max_size_px ? @max_size_px / [width, height].max : 1.0
       actual_max = [@pb.width, @pb.height].max
       src_max = if @max_size_px
-                   [width, height].max
-                 else
-                   [@pb.width, @pb.height].max
-                 end
+                  [width, height].max
+                else
+                  [@pb.width, @pb.height].max
+                end
 
       @scale = actual_max / src_max.to_f
     end

--- a/lib/morandi/image_processor.rb
+++ b/lib/morandi/image_processor.rb
@@ -23,7 +23,7 @@ module Morandi
       @options = (local_options || {}).merge(user_options || {})
       @local_options = local_options
 
-      @scale_to = @options['output.max']
+      @max_size_px = @options['output.max']
       @width = @options['output.width']
       @height = @options['output.height']
     end
@@ -87,10 +87,10 @@ module Morandi
 
     def get_pixbuf
       _, width, height = GdkPixbuf::Pixbuf.get_file_info(@file)
-      @pb = Morandi::ProfiledPixbuf.new(@file, @local_options, @scale_to)
+      @pb = Morandi::ProfiledPixbuf.new(@file, @local_options, @max_size_px)
       @actual_max = [@pb.width, @pb.height].max
 
-      @src_max = if @scale_to
+      @src_max = if @max_size_px
                    [width, height].max
                  else
                    [@pb.width, @pb.height].max

--- a/lib/morandi/image_processor.rb
+++ b/lib/morandi/image_processor.rb
@@ -88,15 +88,17 @@ module Morandi
     def get_pixbuf
       _, width, height = GdkPixbuf::Pixbuf.get_file_info(@file)
       @pb = Morandi::ProfiledPixbuf.new(@file, @local_options, @max_size_px)
-      @actual_max = [@pb.width, @pb.height].max
 
-      @src_max = if @max_size_px
+      # Everything below probably could be substituted with the following:
+      # @scale = @max_size_px ? @max_size_px / [width, height].max : 1.0
+      actual_max = [@pb.width, @pb.height].max
+      src_max = if @max_size_px
                    [width, height].max
                  else
                    [@pb.width, @pb.height].max
                  end
 
-      @scale = @actual_max / @src_max.to_f
+      @scale = actual_max / src_max.to_f
     end
 
     SHARPEN = [

--- a/lib/morandi/image_processor.rb
+++ b/lib/morandi/image_processor.rb
@@ -58,6 +58,10 @@ module Morandi
       @pb = @pb.scale_max([@width, @height].max) if @options['output.limit'] && @width && @height
 
       @pb
+    rescue GdkPixbuf::PixbufError::UnknownType => e
+      raise UnknownTypeError, e.message
+    rescue GdkPixbuf::PixbufError::CorruptImage => e
+      raise CorruptImageError, e.message
     end
 
     # Returns generated pixbuf

--- a/lib/morandi/pixbuf_ext.rb
+++ b/lib/morandi/pixbuf_ext.rb
@@ -10,6 +10,7 @@ module GdkPixbuf
       GdkPixbufCairo.pixbuf_to_surface(self)
     end
 
+    # Proportionally scales down the image so that it fits within max_size*max_size square
     def scale_max(max_size, interp = GdkPixbuf::InterpType::BILINEAR, _max_scale = 1.0)
       mul = (max_size / [width, height].max.to_f)
       mul = [1.0, mul].min

--- a/lib/morandi/profiled_pixbuf.rb
+++ b/lib/morandi/profiled_pixbuf.rb
@@ -37,7 +37,7 @@ module Morandi
 
       if suitable_for_jpegicc?
         icc_file = icc_cache_path
-        valid_jpeg?(icc_file) || system('jpgicc', '-q97', @file, icc_file)
+        valid_jpeg?(icc_file) || system('jpgicc', '-q97', @file, icc_file, out: '/dev/null', err: '/dev/null')
         file = icc_file if valid_jpeg?(icc_file)
       end
 

--- a/lib/morandi/profiled_pixbuf.rb
+++ b/lib/morandi/profiled_pixbuf.rb
@@ -31,7 +31,7 @@ module Morandi
       "#{path}.icc.jpg"
     end
 
-    def initialize(file, local_options, scale_to = nil)
+    def initialize(file, local_options, max_size_px = nil)
       @local_options = local_options
       @file = file
 
@@ -41,8 +41,8 @@ module Morandi
         file = icc_file if valid_jpeg?(icc_file)
       end
 
-      if scale_to
-        super(file: file, width: scale_to, height: scale_to)
+      if max_size_px
+        super(file: file, width: max_size_px, height: max_size_px)
       else
         super(file: file)
       end

--- a/spec/morandi_spec.rb
+++ b/spec/morandi_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Morandi, '#process' do
     describe 'when given a blank file' do
       it 'should fail' do
         File.open(file_in, 'w') { |fp| fp << '' }
-        expect { process_image }.to raise_exception(GdkPixbuf::PixbufError::CorruptImage)
+        expect { process_image }.to raise_exception(Morandi::CorruptImageError)
         expect(File).not_to exist(file_out)
       end
     end
@@ -67,7 +67,7 @@ RSpec.describe Morandi, '#process' do
     describe 'when given a corrupt file' do
       it 'should fail' do
         File.open(file_in, 'ab') { |fp| fp.truncate(64) }
-        expect { process_image }.to raise_exception(GdkPixbuf::PixbufError::CorruptImage)
+        expect { process_image }.to raise_exception(Morandi::CorruptImageError)
         expect(File).not_to exist(file_out)
       end
     end
@@ -76,7 +76,7 @@ RSpec.describe Morandi, '#process' do
       it 'should fail' do
         File.open(file_in, 'wb') { |fp| fp << 'INVALID' }
         (expect { process_image }).to(raise_error do |err|
-          err.is_a?(GdkPixbuf::PixbufError::UnknownType) or err.is_a?(GdkPixbuf::PixbufError::CorruptImage)
+          err.is_a?(Morandi::UnknownTypeError) or err.is_a?(Morandi::CorruptImageError)
         end)
         expect(File).not_to exist(file_out)
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,10 @@ RSpec.configure do |config|
   # the seed, which is printed after each run.
   #     --seed 1234
   config.order = 'random'
+
+  # Allows to use options like --only-failures and --next-failure
+  config.example_status_persistence_file_path = 'tmp/rspec_failures.txt'
+
   config.include ColourHelper
   config.include VisualReportHelper
 


### PR DESCRIPTION
**Background**
I'm prototyping `libvips`-based Morandi on a separate branch in hope of improving its memory profile and performance 

**Problem**
Morandi propagates the GdkPixbuf's errors, making its API strongly coupled to the underlying image processing library

**Solution**
Intercept some of the GdkPixbuf's errors and re-raise Morandi-internal ones

**Decision**
- It's a breaking change, which I indicated in the changelog, but I believe it's worth it for future maintainability, regardless of libvips results
- It was not the only coupling with `GdkPixbuf`; the other big one is `Morandi.process` accepting `Pixbuf` as input, which I don't plan to address ATM

**Notes**
I've also:
- added support for re-running only failed examples for ease of development
- made some minor readability adjustments
- updated github actions to get rid of some CI warnings