### PR TITLE
feat(development): introduce scripts for benchmarking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Better test coverage for straighten operation
 - Support for visual image comparison in specs
 - Automated visual comparison of images in specs, also serving as a record of exact rendering behaviour
+- Development scripts for performing benchmarks
 
 ### Changed
 - Extracted image operations to separate files within a dedicated module

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get update && apt-get install -yyq --no-install-recommends \
   liblcms2-utils \
   # When girepository tries to install implicitly, there's an error due to apt being locked; details in commit message
   libgirepository1.0-dev \
+  # At the time of writing, "time" package is only required for benchmark
+  time \
   && apt-get clean \
   && rm -rf /va/lib/apt/lists/*
 

--- a/bin/benchmark-full
+++ b/bin/benchmark-full
@@ -1,0 +1,111 @@
+#!/usr/bin/env ruby
+
+# frozen_string_literal: true
+
+# A script for benchmarking various image operations in terms of execution time, CPU and memory usage
+# Usage:
+# bundle exec bin/benchmark-full
+
+require 'open3'
+require 'csv'
+require 'json'
+
+# Inputs setup is left here for inspiration, but the actual image files are not part of the repo to avoid clutter
+inputs = [
+  {
+    path: 'tmp/high-res-small-size-16000x11000px.jpg',
+    options: { 'crop' => '815,850,14909,10005', 'straighten' => 0.5, 'gamma' => 0.85 },
+    description: 'Huge, pixelised grayscale gradient'
+  },
+  {
+    path: 'tmp/spider-8288816.jpg',
+    options: { 'crop' => '100,100,6000,4000', 'angle' => 180, 'straighten' => -0.5, 'gamma' => 1.2 },
+    description: '10MB stock photo'
+  },
+  {
+    path: 'tmp/apple-8027938.jpg',
+    options: { 'crop' => '300,300,5000,3000', 'gamma' => 1.0 },
+    description: '1MB stock photo'
+  },
+  {
+    path: 'tmp/IMG_1425.jpg',
+    options: { 'crop' => '100,100,2500,2500', 'straighten' => 0.5, 'gamma' => 0.85 },
+    description: 'A typical phone upload'
+  }
+]
+
+module Morandi
+  # Processes given images using available processors, collecting metrics like duration, CPU and peak RAM usage
+  class FullBenchmark
+    TIME_FORMAT_READABLE = "Real: %es, sys: %S, usr: %U; CPU: %P; RSS max: %MKB\n"
+    TIME_FORMAT_PARSEABLE = '%e,%S,%U,%P,%M'
+    IMAGE_PROCESSORS = %w[pixbuf].freeze
+    ITERATIONS_PER_IMAGE = 10
+
+    def initialize(inputs)
+      @inputs = inputs
+    end
+
+    def perform
+      inputs.each do |input|
+        perform_single(input_image_path: input[:path], options: input[:options], description: input[:description])
+      end
+    end
+
+    private
+
+    attr_reader :inputs
+
+    def perform_single(input_image_path:, options:, description:)
+      log <<~TXT.chomp
+        Processing image: #{input_image_path} (#{description}), #{ITERATIONS_PER_IMAGE} runs
+        Options: #{options.inspect}
+      TXT
+
+      IMAGE_PROCESSORS.each do |image_processor|
+        log "  #{image_processor}:"
+
+        stats = Hash.new { |hash, key| hash[key] = [] }
+        cmd = ['bundle', 'exec',
+               '/usr/bin/time', '--format', TIME_FORMAT_PARSEABLE,
+               'bin/process-single', input_image_path, image_processor, options.to_json]
+
+        ITERATIONS_PER_IMAGE.times do |_i|
+          stdout_str, _status = Open3.capture2e(*cmd)
+          result = parse_single_benchmark_result(stdout_str)
+          result.each { |key, value| stats[key] << value }
+        end
+
+        stats.each do |key, entries|
+          avg = entries.sum / entries.length
+          log "    #{key}: avg #{avg.round(2)}; min #{entries.min.round(2)}; max #{entries.max.round(2)}"
+        end
+      end
+    end
+
+    def log(message)
+      puts message
+    end
+
+    def parse_single_benchmark_result(text_to_parse)
+      result = CSV.parse(text_to_parse).first
+
+      {
+        real_time: result[0].to_f,
+        kernel_time: result[1].to_f,
+        user_time: result[2].to_f,
+        cpu_percentage: result[3].sub('%', '').to_i,
+        rss_max_mb: result[4].to_f / 1024
+      }
+    rescue CSV::MalformedCSVError
+      log "Unexpected data in stdout, data for inspection:\n#{text_to_parse}"
+      raise
+    rescue StandardError
+      log "Unhandled error occurred. Data for inspection:\n#{text_to_parse}"
+      log "Parsed data for inspection:\n#{result}"
+      raise
+    end
+  end
+end
+
+Morandi::FullBenchmark.new(inputs).perform

--- a/bin/process-single
+++ b/bin/process-single
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+
+# frozen_string_literal: true
+
+# A script for performing a single image processing using the given options
+# Example:
+# bundle exec bin/process-single tmp/input.jpg pixbuf '{"angle":180,"straighten":-0.5,"gamma":1.2}'
+
+require 'json'
+require 'morandi'
+
+input_file_path = ARGV[0]
+processor = ARGV[1]
+options_json = ARGV[2]
+
+options = options_json ? JSON.parse(options_json) : { 'straighten' => 0.5, 'gamma' => 0.85 }
+local_options = {}
+
+processor_instance = case processor
+                     when 'pixbuf'
+                       Morandi::ImageProcessor.new(input_file_path, options, local_options).tap(&:result)
+                     else
+                       raise("Not a supported processor: #{processor}")
+                     end
+
+output_path = "#{input_file_path}-#{processor}-output.jpg"
+processor_instance.write_to_jpeg(output_path)


### PR DESCRIPTION
**Background**
I'm prototyping `libvips`-based Morandi on a separate branch in hope of improving its memory profile and performance

**Problem**
There's no easy way of checking the properties (duration, peak RAM, CPU usage) of various image processing implementations

**Solution**
Introduce benchmarking scripts

**Notes**
Example output:
```
Processing image: tmp/high-res-small-size-16000x11000px.jpg (Huge, pixelised grayscale gradient), 10 runs
Options: {"crop"=>"815,850,14909,10005", "straighten"=>0.5, "gamma"=>0.85}
  pixbuf:
    real_time: avg 8.27; min 7.39; max 10.39
    kernel_time: avg 1.34; min 1.15; max 1.7
    user_time: avg 6.66; min 5.97; max 8.31
    cpu_percentage: avg 96; min 96; max 97
    rss_max_mb: avg 2430.38; min 2430.07; max 2430.73
Processing image: tmp/spider-8288816.jpg (10MB stock photo), 10 runs
Options: {"crop"=>"100,100,6000,4000", "angle"=>180, "straighten"=>-0.5, "gamma"=>1.2}
  pixbuf:
    real_time: avg 4.34; min 3.96; max 4.97
    kernel_time: avg 0.45; min 0.37; max 0.59
    user_time: avg 3.35; min 3.05; max 3.9
    cpu_percentage: avg 87; min 86; max 88
    rss_max_mb: avg 456.91; min 456.66; max 457.18
Processing image: tmp/apple-8027938.jpg (1MB stock photo), 10 runs
Options: {"crop"=>"300,300,5000,3000", "gamma"=>1.0}
  pixbuf:
    real_time: avg 3.26; min 2.19; max 4.86
    kernel_time: avg 0.22; min 0.13; max 0.31
    user_time: avg 2.83; min 1.89; max 4.25
    cpu_percentage: avg 92; min 91; max 95
    rss_max_mb: avg 140.48; min 140.34; max 140.67
Processing image: tmp/IMG_1425.jpg (A typical phone upload), 10 runs
Options: {"crop"=>"100,100,2500,2500", "straighten"=>0.5, "gamma"=>0.85}
  pixbuf:
    real_time: avg 2.93; min 2.45; max 4.17
    kernel_time: avg 0.22; min 0.15; max 0.33
    user_time: avg 2.52; min 2.14; max 3.54
    cpu_percentage: avg 93; min 92; max 95
    rss_max_mb: avg 243.08; min 242.69; max 243.46
```