### PR TITLE
feat: prepare code for a new image processor

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -25,6 +25,7 @@ Metrics/BlockLength:
   AllowedMethods:
   - describe
   - context
+  - shared_examples
 
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.

--- a/lib/morandi.rb
+++ b/lib/morandi.rb
@@ -27,8 +27,8 @@ module Morandi
   # @option options [Array[Integer,Integer,Integer,Integer]] 'crop' Crop image (x, y, width, height)
   # @option options [String] 'fx' Apply colour filters ('greyscale', 'sepia', 'bluetone')
   # @option options [String] 'border-style' Set border style ('square', 'retro')
-  # @option options [String] 'background-style' Set border colour ('retro', 'black', 'white')
-  # @option options [String] 'quality' ('97') Set JPG compression value ('1' to '100')
+  # @option options [String] 'background-style' Set border colour ('retro', 'black', 'white', 'dominant')
+  # @option options [Integer] 'quality' (97) Set JPG compression value (1 to 100)
   # @option options [Integer] 'output.max' Downscales the image to fit within the square of given size before
   #                                        processing to limit the required resources
   # @option options [Integer] 'output.width' Sets desired width of resulting image

--- a/spec/morandi_spec.rb
+++ b/spec/morandi_spec.rb
@@ -338,7 +338,6 @@ RSpec.describe Morandi, '#process' do
     let(:options) { { 'gamma' => 2.0 } }
 
     it 'should apply the gamma to the image' do
-      expect(MorandiNative::PixbufUtils).to receive(:gamma).and_call_original
       process_image
 
       expect(File).to exist(file_out)

--- a/spec/morandi_spec.rb
+++ b/spec/morandi_spec.rb
@@ -436,7 +436,7 @@ RSpec.describe Morandi, '#process' do
 
         expect(processed_image_width).to eq(pixbuf.width)
         expect(processed_image_height).to eq(pixbuf.height)
-        # Pixbuf no-op is slightly different than file no-op because icc colour profile processing only happens for files
+        # Pixbuf's no-op is different than file no-op because icc colour profile processing only happens for files
         expect(file_out).to match_reference_image('plasma-from-pixbuf-no-op-output')
       end
     end

--- a/spec/morandi_spec.rb
+++ b/spec/morandi_spec.rb
@@ -429,7 +429,7 @@ RSpec.describe Morandi, '#process' do
       process_image
 
       expect(processed_image_width).to eq output_width
-      expect(processed_image_height).to eq 243 # NOTE: more than output_height, very confusing!
+      expect(processed_image_height).to be_between(243, 244) # NOTE: more than output_height, very confusing!
     end
 
     context 'with output orientation being different than input' do
@@ -440,7 +440,7 @@ RSpec.describe Morandi, '#process' do
         process_image
 
         expect(processed_image_width).to eq 300 # NOTE: restricting width based on output.height
-        expect(processed_image_height).to eq 243
+        expect(processed_image_height).to be_between(243, 244)
       end
     end
   end

--- a/spec/morandi_spec.rb
+++ b/spec/morandi_spec.rb
@@ -50,7 +50,9 @@ RSpec.describe Morandi, '#process' do
   describe 'when given a blank file' do
     it 'should fail' do
       File.open(file_in, 'w') { |fp| fp << '' }
-      expect { process_image }.to raise_exception(Morandi::CorruptImageError)
+      (expect { process_image }).to(raise_error do |err|
+        err.is_a?(Morandi::UnknownTypeError) or err.is_a?(Morandi::CorruptImageError)
+      end)
       expect(File).not_to exist(file_out)
     end
   end

--- a/spec/morandi_spec.rb
+++ b/spec/morandi_spec.rb
@@ -39,277 +39,196 @@ RSpec.describe Morandi, '#process' do
     FileUtils.remove_dir('sample/')
   end
 
-  describe 'when given an input without any options' do
-    it 'creates output' do
-      process_image
-      expect(File).to exist(file_out)
-      expect(file_out).to match_reference_image('plasma-no-op-output')
-    end
-  end
-
-  describe 'when given a blank file' do
-    it 'should fail' do
-      File.open(file_in, 'w') { |fp| fp << '' }
-      (expect { process_image }).to(raise_error do |err|
-        err.is_a?(Morandi::UnknownTypeError) or err.is_a?(Morandi::CorruptImageError)
-      end)
-      expect(File).not_to exist(file_out)
-    end
-  end
-
-  describe 'when given a corrupt file' do
-    it 'should fail' do
-      File.open(file_in, 'ab') { |fp| fp.truncate(64) }
-      expect { process_image }.to raise_exception(Morandi::CorruptImageError)
-      expect(File).not_to exist(file_out)
-    end
-  end
-
-  describe 'when given a invalid file format' do
-    it 'should fail' do
-      File.open(file_in, 'wb') { |fp| fp << 'INVALID' }
-      (expect { process_image }).to(raise_error do |err|
-        err.is_a?(Morandi::UnknownTypeError) or err.is_a?(Morandi::CorruptImageError)
-      end)
-      expect(File).not_to exist(file_out)
-    end
-  end
-
-  describe 'with a big image and a bigger cropped area to fill' do
-    let(:options) do
-      {
-        'crop' => '0,477,15839,18804',
-        'angle' => 90,
-        'fx' => 'colour',
-        'straighten' => 0.0,
-        'gamma' => 0.98,
-        'redeye' => []
-      }
-    end
-
-    it 'creates output' do
-      process_image
-      expect(File).to exist(file_out)
-      expect(processed_image_type).to eq('jpeg')
-      expect(processed_image_width).to eq 15_839
-      expect(processed_image_height).to eq 18_804
-    end
-  end
-
-  describe 'when given an angle of rotation' do
-    let(:options) { { 'angle' => angle } }
-
-    context '90 degress' do
-      let(:angle) { 90 }
-
-      it 'rotates the image' do
+  shared_examples 'an image processor' do
+    describe 'when given an input without any options' do
+      it 'creates output' do
         process_image
-        expect(file_out).to match_reference_image('plasma-rotated-90')
-      end
-    end
-
-    context '180 degress' do
-      let(:angle) { 180 }
-
-      it 'rotates the image' do
-        process_image
-        expect(file_out).to match_reference_image('plasma-rotated-180')
-      end
-    end
-
-    context '270 degress' do
-      let(:angle) { 270 }
-
-      it 'rotates the image' do
-        process_image
-        expect(file_out).to match_reference_image('plasma-rotated-270')
-      end
-    end
-
-    context '360 degress' do
-      let(:angle) { 360 }
-
-      it 'does not perform any rotation' do
-        process_image
+        expect(File).to exist(file_out)
         expect(file_out).to match_reference_image('plasma-no-op-output')
       end
     end
-  end
 
-  describe 'when given a pixbuf as an input' do
-    subject(:process_image) do
-      Morandi.process(pixbuf, options, file_out)
+    describe 'when given a blank file' do
+      it 'should fail' do
+        File.open(file_in, 'w') { |fp| fp << '' }
+        (expect { process_image }).to(raise_error do |err|
+          err.is_a?(Morandi::UnknownTypeError) or err.is_a?(Morandi::CorruptImageError)
+        end)
+        expect(File).not_to exist(file_out)
+      end
     end
 
-    let(:pixbuf) { GdkPixbuf::Pixbuf.new(file: file_in) }
-
-    it 'should process the file' do
-      process_image
-
-      expect(processed_image_width).to eq(pixbuf.width)
-      expect(processed_image_height).to eq(pixbuf.height)
-      # Pixbuf no-op is slightly different than file no-op because icc colour profile processing only happens for files
-      expect(file_out).to match_reference_image('plasma-from-pixbuf-no-op-output')
+    describe 'when given a corrupt file' do
+      it 'should fail' do
+        File.open(file_in, 'ab') { |fp| fp.truncate(64) }
+        expect { process_image }.to raise_exception(Morandi::CorruptImageError)
+        expect(File).not_to exist(file_out)
+      end
     end
-  end
 
-  context 'when give a "crop" option' do
-    let(:cropped_width) { 300 }
-    let(:cropped_height) { 300 }
+    describe 'when given a invalid file format' do
+      it 'should fail' do
+        File.open(file_in, 'wb') { |fp| fp << 'INVALID' }
+        (expect { process_image }).to(raise_error do |err|
+          err.is_a?(Morandi::UnknownTypeError) or err.is_a?(Morandi::CorruptImageError)
+        end)
+        expect(File).not_to exist(file_out)
+      end
+    end
 
-    describe 'when given an array of dimensions' do
-      let(:options) { { 'crop' => [10, 10, cropped_width, cropped_height] } }
+    describe 'with a big image and a bigger cropped area to fill' do
+      let(:options) do
+        {
+          'crop' => '0,477,15839,18804',
+          'angle' => 90,
+          'fx' => 'colour',
+          'straighten' => 0.0,
+          'gamma' => 0.98,
+          'redeye' => []
+        }
+      end
 
-      it 'should crop the image' do
+      it 'creates output' do
+        process_image
+        expect(File).to exist(file_out)
+        expect(processed_image_type).to eq('jpeg')
+        expect(processed_image_width).to eq 15_839
+        expect(processed_image_height).to eq 18_804
+      end
+    end
+
+    describe 'when given an angle of rotation' do
+      let(:options) { { 'angle' => angle } }
+
+      context '90 degress' do
+        let(:angle) { 90 }
+
+        it 'rotates the image' do
+          process_image
+          expect(file_out).to match_reference_image('plasma-rotated-90')
+        end
+      end
+
+      context '180 degress' do
+        let(:angle) { 180 }
+
+        it 'rotates the image' do
+          process_image
+          expect(file_out).to match_reference_image('plasma-rotated-180')
+        end
+      end
+
+      context '270 degress' do
+        let(:angle) { 270 }
+
+        it 'rotates the image' do
+          process_image
+          expect(file_out).to match_reference_image('plasma-rotated-270')
+        end
+      end
+
+      context '360 degress' do
+        let(:angle) { 360 }
+
+        it 'does not perform any rotation' do
+          process_image
+          expect(file_out).to match_reference_image('plasma-no-op-output')
+        end
+      end
+    end
+
+    context 'when give a "crop" option' do
+      let(:cropped_width) { 300 }
+      let(:cropped_height) { 300 }
+
+      describe 'when given an array of dimensions' do
+        let(:options) { { 'crop' => [10, 10, cropped_width, cropped_height] } }
+
+        it 'should crop the image' do
+          process_image
+
+          expect(File).to exist(file_out)
+          expect(processed_image_width).to eq(cropped_width)
+          expect(processed_image_height).to eq(cropped_height)
+
+          expect(file_out).to match_reference_image('plasma-cropped')
+        end
+      end
+
+      describe 'when given a string of dimensions' do
+        let(:options) { { 'crop' => "10,10,#{cropped_width},#{cropped_height}" } }
+
+        it 'should do cropping of images with a string' do
+          process_image
+
+          expect(File).to exist(file_out)
+          expect(processed_image_width).to eq(cropped_width)
+          expect(processed_image_height).to eq(cropped_height)
+
+          expect(file_out).to match_reference_image('plasma-cropped')
+        end
+      end
+
+      describe 'with negative initial coordinates' do
+        let(:options) { { 'crop' => [-50, -50, cropped_width, cropped_height] } }
+
+        it 'crops the image to desired dimensions' do
+          process_image
+
+          expect(File).to exist(file_out)
+          expect(processed_image_width).to eq(cropped_width)
+          expect(processed_image_height).to eq(cropped_height)
+
+          expect(file_out).to match_reference_image('plasma-cropped-negative-initial-coords')
+        end
+      end
+
+      describe 'with desired dimensions exceeding the size of original image' do
+        let(:options) { { 'crop' => [0, 0, original_image_width + 50, original_image_height + 50] } }
+
+        it 'crops the image to desired dimensions' do
+          process_image
+
+          expect(File).to exist(file_out)
+          expect(processed_image_width).to eq(original_image_width + 50)
+          expect(processed_image_height).to eq(original_image_height + 50)
+
+          expect(file_out).to match_reference_image('plasma-cropped-excessive-size')
+        end
+      end
+
+      describe 'with negative dimensions' do
+        let(:options) { { 'crop' => [0, 0, -10, -10] } }
+
+        it 'crops the image to 1x1px' do
+          process_image
+
+          expect(File).to exist(file_out)
+          expect(processed_image_width).to eq(1)
+          expect(processed_image_height).to eq(1)
+
+          expect(file_out).to match_reference_image('plasma-cropped-1x1')
+        end
+      end
+    end
+
+    describe 'when given an output.max option' do
+      let(:options) { { 'output.max' => max_size } }
+      let(:max_size) { 200 }
+
+      it 'should reduce the size of images' do
         process_image
 
         expect(File).to exist(file_out)
-        expect(processed_image_width).to eq(cropped_width)
-        expect(processed_image_height).to eq(cropped_height)
+        expect(processed_image_width).to be <= (max_size)
+        expect(processed_image_height).to be <= (max_size)
 
-        expect(file_out).to match_reference_image('plasma-cropped')
+        expect(file_out).to match_reference_image('plasma-constrained-output-size')
       end
     end
 
-    describe 'when given a string of dimensions' do
-      let(:options) { { 'crop' => "10,10,#{cropped_width},#{cropped_height}" } }
-
-      it 'should do cropping of images with a string' do
-        process_image
-
-        expect(File).to exist(file_out)
-        expect(processed_image_width).to eq(cropped_width)
-        expect(processed_image_height).to eq(cropped_height)
-
-        expect(file_out).to match_reference_image('plasma-cropped')
-      end
-    end
-
-    describe 'with negative initial coordinates' do
-      let(:options) { { 'crop' => [-50, -50, cropped_width, cropped_height] } }
-
-      it 'crops the image to desired dimensions' do
-        process_image
-
-        expect(File).to exist(file_out)
-        expect(processed_image_width).to eq(cropped_width)
-        expect(processed_image_height).to eq(cropped_height)
-
-        expect(file_out).to match_reference_image('plasma-cropped-negative-initial-coords')
-      end
-    end
-
-    describe 'with desired dimensions exceeding the size of original image' do
-      let(:options) { { 'crop' => [0, 0, original_image_width + 50, original_image_height + 50] } }
-
-      it 'crops the image to desired dimensions' do
-        process_image
-
-        expect(File).to exist(file_out)
-        expect(processed_image_width).to eq(original_image_width + 50)
-        expect(processed_image_height).to eq(original_image_height + 50)
-
-        expect(file_out).to match_reference_image('plasma-cropped-excessive-size')
-      end
-    end
-
-    describe 'with negative dimensions' do
-      let(:options) { { 'crop' => [0, 0, -10, -10] } }
-
-      it 'crops the image to 1x1px' do
-        process_image
-
-        expect(File).to exist(file_out)
-        expect(processed_image_width).to eq(1)
-        expect(processed_image_height).to eq(1)
-
-        expect(file_out).to match_reference_image('plasma-cropped-1x1')
-      end
-    end
-  end
-
-  describe 'when the user supplies a path.icc in the "local_options" argument' do
-    subject(:process_image) do
-      Morandi.process(file_in, options, file_out, local_options)
-    end
-
-    let(:icc_path) { 'sample/icc_secure_test.jpg' }
-    let(:local_options) { { 'path.icc' => icc_path } }
-    let(:icc_width) { 900 }
-    let(:icc_height) { 400 }
-
-    before do
-      generate_test_image(icc_path, icc_width, icc_height)
-    end
-
-    it 'should use a file at this location as the input' do
-      process_image
-
-      expect(File).to exist(file_out)
-      expect(processed_image_width).to eq(icc_width)
-      expect(processed_image_height).to eq(icc_height)
-    end
-
-    context 'if no file at this location exists' do
-      let(:different_icc_path) { 'sample/different_secure_test.jpg' }
-      let(:local_options) { { 'path.icc' => different_icc_path } }
-
-      it 'should create one' do
-        process_image
-
-        expect(File).to exist(different_icc_path)
-      end
-    end
-  end
-
-  describe 'when the user supplies a path.icc in the "options" argument' do
-    let(:icc_path) { 'sample/icc_insecure_test.jpg' }
-    let(:options) { { 'path.icc' => icc_path } }
-    let(:icc_width) { 900 }
-    let(:icc_height) { 400 }
-
-    before do
-      generate_test_image(icc_path, icc_width, icc_height)
-    end
-
-    it 'should ignore the file at this path' do
-      process_image
-
-      expect(File).to exist(file_out)
-      expect(processed_image_width).not_to eq(icc_width)
-      expect(processed_image_height).not_to eq(icc_height)
-    end
-  end
-
-  describe 'when given an output.max option' do
-    let(:options) { { 'output.max' => max_size } }
-    let(:max_size) { 200 }
-
-    it 'should reduce the size of images' do
-      process_image
-
-      expect(File).to exist(file_out)
-      expect(processed_image_width).to be <= (max_size)
-      expect(processed_image_height).to be <= (max_size)
-
-      expect(file_out).to match_reference_image('plasma-constrained-output-size')
-    end
-  end
-
-  describe 'when given a straighten option' do
-    let(:options) { { 'straighten' => 5 } }
-
-    it 'straightens images' do
-      process_image
-
-      expect(File).to exist(file_out)
-      expect(processed_image_type).to eq('jpeg')
-
-      expect(file_out).to match_reference_image('plasma-straighten-positive-5')
-    end
-
-    context 'with a negative straighten value' do
-      let(:options) { { 'straighten' => -20 } }
+    describe 'when given a straighten option' do
+      let(:options) { { 'straighten' => 5 } }
 
       it 'straightens images' do
         process_image
@@ -317,209 +236,406 @@ RSpec.describe Morandi, '#process' do
         expect(File).to exist(file_out)
         expect(processed_image_type).to eq('jpeg')
 
-        expect(file_out).to match_reference_image('plasma-straighten-negative-20')
+        expect(file_out).to match_reference_image('plasma-straighten-positive-5')
+      end
+
+      context 'with a negative straighten value' do
+        let(:options) { { 'straighten' => -20 } }
+
+        it 'straightens images' do
+          process_image
+
+          expect(File).to exist(file_out)
+          expect(processed_image_type).to eq('jpeg')
+
+          expect(file_out).to match_reference_image('plasma-straighten-negative-20')
+        end
+      end
+
+      context 'with vertical image' do
+        let(:original_image_width) { 100 }
+        let(:original_image_height) { 400 }
+
+        it 'straightens images' do
+          process_image
+
+          expect(File).to exist(file_out)
+          expect(processed_image_type).to eq('jpeg')
+
+          expect(file_out).to match_reference_image('plasma-straighten-on-vertical-image')
+        end
       end
     end
 
-    context 'with vertical image' do
-      let(:original_image_width) { 100 }
-      let(:original_image_height) { 400 }
+    describe 'when given a gamma option' do
+      let(:options) { { 'gamma' => 2.0 } }
 
-      it 'straightens images' do
+      it 'should apply the gamma to the image' do
         process_image
 
         expect(File).to exist(file_out)
         expect(processed_image_type).to eq('jpeg')
 
-        expect(file_out).to match_reference_image('plasma-straighten-on-vertical-image')
+        expect(file_out).to match_reference_image('plasma-gamma')
       end
     end
-  end
 
-  describe 'when given a gamma option' do
-    let(:options) { { 'gamma' => 2.0 } }
+    describe 'when given an fx option' do
+      let(:options) { { 'fx' => filter_name } }
 
-    it 'should apply the gamma to the image' do
-      process_image
+      context 'with sepia' do
+        let(:filter_name) { 'sepia' }
 
-      expect(File).to exist(file_out)
-      expect(processed_image_type).to eq('jpeg')
+        it 'applies filter to the image' do
+          process_image
 
-      expect(file_out).to match_reference_image('plasma-gamma')
+          expect(File).to exist(file_out)
+          expect(processed_image_type).to eq('jpeg')
+          expect(file_out).to match_reference_image('plasma-sepia')
+        end
+      end
+
+      context 'with bluetone' do
+        let(:filter_name) { 'bluetone' }
+
+        it 'applies filter to the image' do
+          process_image
+
+          expect(File).to exist(file_out)
+          expect(processed_image_type).to eq('jpeg')
+          expect(file_out).to match_reference_image('plasma-bluetone')
+        end
+      end
+
+      context 'with greyscale' do
+        let(:filter_name) { 'greyscale' }
+
+        it 'applies filter to the image' do
+          process_image
+
+          expect(File).to exist(file_out)
+          expect(processed_image_type).to eq('jpeg')
+          expect(file_out).to match_reference_image('plasma-greyscale')
+        end
+      end
     end
-  end
 
-  describe 'when given an fx option' do
-    let(:options) { { 'fx' => filter_name } }
+    describe 'when changing the dimensions and auto-cropping' do
+      let(:max_width) { 300 }
+      let(:max_height) { 200 }
 
-    context 'with sepia' do
-      let(:filter_name) { 'sepia' }
+      let(:options) do
+        {
+          'output.width' => max_width,
+          'output.height' => max_height,
+          'image.auto-crop' => true,
+          'output.limit' => true
+        }
+      end
 
-      it 'applies filter to the image' do
+      it 'should output at the specified size, or less' do
         process_image
 
         expect(File).to exist(file_out)
         expect(processed_image_type).to eq('jpeg')
-        expect(file_out).to match_reference_image('plasma-sepia')
+        expect(processed_image_width).to be <= max_width
+        expect(processed_image_height).to be <= max_height
+
+        expect(file_out).to match_reference_image('plasma-auto-cropped')
       end
     end
 
-    context 'with bluetone' do
-      let(:filter_name) { 'bluetone' }
+    describe 'with limiting the output size without autocrop' do
+      let(:output_width) { 300 }
+      let(:output_height) { 200 }
 
-      it 'applies filter to the image' do
+      let(:options) do
+        {
+          'output.width' => output_width,
+          'output.height' => output_height,
+          'image.auto-crop' => false,
+          'output.limit' => true
+        }
+      end
+
+      it 'scales the entire image proportionally to fit within the square of higher dimension size' do
         process_image
 
-        expect(File).to exist(file_out)
-        expect(processed_image_type).to eq('jpeg')
-        expect(file_out).to match_reference_image('plasma-bluetone')
+        expect(processed_image_width).to eq output_width
+        expect(processed_image_height).to be_between(243, 244) # NOTE: more than output_height, very confusing!
+      end
+
+      context 'with output orientation being different than input' do
+        let(:output_width) { 200 }
+        let(:output_height) { 300 }
+
+        it 'constraints based on the higher dimension size' do
+          process_image
+
+          expect(processed_image_width).to eq 300 # NOTE: restricting width based on output.height
+          expect(processed_image_height).to be_between(243, 244)
+        end
       end
     end
 
-    context 'with greyscale' do
-      let(:filter_name) { 'greyscale' }
+    context 'with non-sRGB colour profile' do
+      let(:file_in) { 'spec/fixtures/pumpkins-icc-adobe-rgb-1998.jpg' }
 
-      it 'applies filter to the image' do
+      it 'converts the profile to sRGB' do
         process_image
 
-        expect(File).to exist(file_out)
-        expect(processed_image_type).to eq('jpeg')
-        expect(file_out).to match_reference_image('plasma-greyscale')
+        expect(file_out).to match_reference_image('pumpkins-icc-adobe-rgb-1998-processed-without-modifications')
       end
     end
-  end
 
-  describe 'when changing the dimensions and auto-cropping' do
-    let(:max_width) { 300 }
-    let(:max_height) { 200 }
+    context 'with increasing quality settings' do
+      let!(:max_quality_file) do
+        Morandi.process(file_in, { 'quality' => 100 }, 'sample/out-100.jpg')
+      end
 
-    let(:options) do
-      {
-        'output.width' => max_width,
-        'output.height' => max_height,
-        'image.auto-crop' => true,
-        'output.limit' => true
-      }
-    end
+      let(:max_quality_file_size) { File.size('sample/out-100.jpg') }
 
-    it 'should output at the specified size, or less' do
-      process_image
+      let!(:default_of_97_quality_file) do
+        Morandi.process(file_in, {}, 'sample/out-97.jpg')
+      end
 
-      expect(File).to exist(file_out)
-      expect(processed_image_type).to eq('jpeg')
-      expect(processed_image_width).to be <= max_width
-      expect(processed_image_height).to be <= max_height
+      let(:default_of_97_quality_file_size) { File.size('sample/out-97.jpg') }
 
-      expect(file_out).to match_reference_image('plasma-auto-cropped')
-    end
-  end
+      let!(:quality_of_40_file) do
+        Morandi.process(file_in, { 'quality' => 40 }, 'sample/out-40.jpg')
+      end
 
-  describe 'with limiting the output size without autocrop' do
-    let(:output_width) { 300 }
-    let(:output_height) { 200 }
+      let(:quality_of_40_file_size) { File.size('sample/out-40.jpg') }
 
-    let(:options) do
-      {
-        'output.width' => output_width,
-        'output.height' => output_height,
-        'image.auto-crop' => false,
-        'output.limit' => true
-      }
-    end
+      let(:created_file_sizes) do
+        [default_of_97_quality_file_size, max_quality_file_size, quality_of_40_file_size]
+      end
 
-    it 'scales the entire image proportionally to fit within the square of higher dimension size' do
-      process_image
+      let(:files_in_increasing_quality_order) do
+        [quality_of_40_file_size, default_of_97_quality_file_size, max_quality_file_size]
+      end
 
-      expect(processed_image_width).to eq output_width
-      expect(processed_image_height).to be_between(243, 244) # NOTE: more than output_height, very confusing!
-    end
-
-    context 'with output orientation being different than input' do
-      let(:output_width) { 200 }
-      let(:output_height) { 300 }
-
-      it 'constraints based on the higher dimension size' do
-        process_image
-
-        expect(processed_image_width).to eq 300 # NOTE: restricting width based on output.height
-        expect(processed_image_height).to be_between(243, 244)
+      it 'creates files of increasing size' do
+        expect(created_file_sizes.sort).to eq(files_in_increasing_quality_order)
       end
     end
   end
 
-  describe 'when given a redeye option' do
-    let(:file_in) { 'spec/fixtures/public-domain-redeye-image-from-wikipedia.jpg' }
-    let(:options) { { 'redeye' => [[540, 650]] } }
+  context 'pixbuf processor' do
+    it_behaves_like 'an image processor'
 
-    it 'should correct the redeye' do
-      process_image
+    describe 'when given a pixbuf as an input' do
+      subject(:process_image) do
+        Morandi.process(pixbuf, options, file_out)
+      end
 
-      expect(File).to exist(file_out)
-      expect(processed_image_type).to eq('jpeg')
+      let(:pixbuf) { GdkPixbuf::Pixbuf.new(file: file_in) }
 
-      expect(crude_average_colour(GdkPixbuf::Pixbuf.new(file: file_in).subpixbuf(505, 605, 100,
-                                                                                 100))).to be_redish
-      expect(crude_average_colour(GdkPixbuf::Pixbuf.new(file: file_out).subpixbuf(505, 605, 100,
-                                                                                  100))).to be_greyish
+      it 'should process the file' do
+        process_image
 
-      expect(file_out).to match_reference_image('redeye-correction')
+        expect(processed_image_width).to eq(pixbuf.width)
+        expect(processed_image_height).to eq(pixbuf.height)
+        # Pixbuf no-op is slightly different than file no-op because icc colour profile processing only happens for files
+        expect(file_out).to match_reference_image('plasma-from-pixbuf-no-op-output')
+      end
     end
 
-    context 'with a gray image and invalid spots' do
-      let(:file_arg) { solid_colour_image(800, 800, 0x666666ff) }
-      let(:options) { { 'redeye' => [[540, 650], [-100, 100]] } }
+    describe 'when the user supplies a path.icc in the "local_options" argument' do
+      subject(:process_image) do
+        Morandi.process(file_in, options, file_out, local_options)
+      end
 
-      it 'should not break or corrupt the image' do
+      let(:icc_path) { 'sample/icc_secure_test.jpg' }
+      let(:local_options) { { 'path.icc' => icc_path } }
+      let(:icc_width) { 900 }
+      let(:icc_height) { 400 }
+
+      before do
+        generate_test_image(icc_path, icc_width, icc_height)
+      end
+
+      it 'should use a file at this location as the input' do
+        process_image
+
+        expect(File).to exist(file_out)
+        expect(processed_image_width).to eq(icc_width)
+        expect(processed_image_height).to eq(icc_height)
+      end
+
+      context 'if no file at this location exists' do
+        let(:different_icc_path) { 'sample/different_secure_test.jpg' }
+        let(:local_options) { { 'path.icc' => different_icc_path } }
+
+        it 'should create one' do
+          process_image
+
+          expect(File).to exist(different_icc_path)
+        end
+      end
+    end
+
+    describe 'when the user supplies a path.icc in the "options" argument' do
+      let(:icc_path) { 'sample/icc_insecure_test.jpg' }
+      let(:options) { { 'path.icc' => icc_path } }
+      let(:icc_width) { 900 }
+      let(:icc_height) { 400 }
+
+      before do
+        generate_test_image(icc_path, icc_width, icc_height)
+      end
+
+      it 'should ignore the file at this path' do
+        process_image
+
+        expect(File).to exist(file_out)
+        expect(processed_image_width).not_to eq(icc_width)
+        expect(processed_image_height).not_to eq(icc_height)
+      end
+    end
+
+    describe 'when given a redeye option' do
+      let(:file_in) { 'spec/fixtures/public-domain-redeye-image-from-wikipedia.jpg' }
+      let(:options) { { 'redeye' => [[540, 650]] } }
+
+      it 'should correct the redeye' do
         process_image
 
         expect(File).to exist(file_out)
         expect(processed_image_type).to eq('jpeg')
 
-        expect(crude_average_colour(file_arg.subpixbuf(505, 605, 100, 100))).to be_greyish
+        expect(crude_average_colour(GdkPixbuf::Pixbuf.new(file: file_in).subpixbuf(505, 605, 100,
+                                                                                   100))).to be_redish
         expect(crude_average_colour(GdkPixbuf::Pixbuf.new(file: file_out).subpixbuf(505, 605, 100,
                                                                                     100))).to be_greyish
+
+        expect(file_out).to match_reference_image('redeye-correction')
+      end
+
+      context 'with a gray image and invalid spots' do
+        let(:file_arg) { solid_colour_image(800, 800, 0x666666ff) }
+        let(:options) { { 'redeye' => [[540, 650], [-100, 100]] } }
+
+        it 'should not break or corrupt the image' do
+          process_image
+
+          expect(File).to exist(file_out)
+          expect(processed_image_type).to eq('jpeg')
+
+          expect(crude_average_colour(file_arg.subpixbuf(505, 605, 100, 100))).to be_greyish
+          expect(crude_average_colour(GdkPixbuf::Pixbuf.new(file: file_out).subpixbuf(505, 605, 100,
+                                                                                      100))).to be_greyish
+        end
       end
     end
-  end
 
-  describe 'when given a negative sharpen option' do
-    let(:options) { { 'sharpen' => -3 } }
+    describe 'when given a negative sharpen option' do
+      let(:options) { { 'sharpen' => -3 } }
 
-    it 'should blur the image' do
-      process_image
+      it 'should blur the image' do
+        process_image
 
-      expect(File).to exist(file_out)
-      expect(processed_image_type).to eq('jpeg')
-      expect(file_out).to match_reference_image('plasma-blurred')
-    end
-  end
-
-  describe 'when given a postive sharpen option' do
-    let(:options) { { 'sharpen' => 3 } }
-
-    it 'should sharpen the image' do
-      process_image
-
-      expect(File).to exist(file_out)
-      expect(processed_image_type).to eq('jpeg')
-
-      expect(file_out).to match_reference_image('plasma-sharpened')
-    end
-  end
-
-  describe 'when applying a border and maintaining the original size' do
-    let(:options) do
-      {
-        'border-style' => 'square',
-        'background-style' => background_style,
-        'border-size-mm' => 5,
-        'output.width' => original_image_width,
-        'output.height' => original_image_height
-      }
+        expect(File).to exist(file_out)
+        expect(processed_image_type).to eq('jpeg')
+        expect(file_out).to match_reference_image('plasma-blurred')
+      end
     end
 
-    context 'dominant colour background' do
-      let(:background_style) { 'dominant' }
+    describe 'when given a postive sharpen option' do
+      let(:options) { { 'sharpen' => 3 } }
+
+      it 'should sharpen the image' do
+        process_image
+
+        expect(File).to exist(file_out)
+        expect(processed_image_type).to eq('jpeg')
+
+        expect(file_out).to match_reference_image('plasma-sharpened')
+      end
+    end
+
+    describe 'when applying a border and maintaining the original size' do
+      let(:options) do
+        {
+          'border-style' => 'square',
+          'background-style' => background_style,
+          'border-size-mm' => 5,
+          'output.width' => original_image_width,
+          'output.height' => original_image_height
+        }
+      end
+
+      context 'dominant colour background' do
+        let(:background_style) { 'dominant' }
+
+        it 'should maintain the target size' do
+          process_image
+
+          expect(File).to exist(file_out)
+          expect(processed_image_type).to eq('jpeg')
+          expect(processed_image_width).to eq(original_image_width)
+          expect(processed_image_height).to eq(original_image_height)
+
+          expect(file_out).to match_reference_image('plasma-bordered-dominant')
+        end
+      end
+
+      context 'black colour background' do
+        let(:background_style) { 'black' }
+
+        it 'should maintain the target size' do
+          process_image
+
+          expect(File).to exist(file_out)
+          expect(processed_image_type).to eq('jpeg')
+          expect(processed_image_width).to eq(original_image_width)
+          expect(processed_image_height).to eq(original_image_height)
+
+          expect(file_out).to match_reference_image('plasma-bordered-black')
+        end
+      end
+
+      context 'white colour background' do
+        let(:background_style) { 'white' }
+
+        it 'should maintain the target size' do
+          process_image
+
+          expect(File).to exist(file_out)
+          expect(processed_image_type).to eq('jpeg')
+          expect(processed_image_width).to eq(original_image_width)
+          expect(processed_image_height).to eq(original_image_height)
+
+          expect(file_out).to match_reference_image('plasma-bordered-white')
+        end
+      end
+
+      context 'retro colour background' do
+        let(:background_style) { 'retro' }
+
+        it 'should maintain the target size' do
+          process_image
+
+          expect(File).to exist(file_out)
+          expect(processed_image_type).to eq('jpeg')
+          expect(processed_image_width).to eq(original_image_width)
+          expect(processed_image_height).to eq(original_image_height)
+
+          expect(file_out).to match_reference_image('plasma-bordered-retro-background')
+        end
+      end
+    end
+
+    describe 'when applying a retro border and maintaining the original size' do
+      let(:options) do
+        {
+          'border-style' => 'retro',
+          'background-style' => 'dominant',
+          'border-size-mm' => 5,
+          'output.width' => original_image_width,
+          'output.height' => original_image_height
+        }
+      end
 
       it 'should maintain the target size' do
         process_image
@@ -529,149 +645,39 @@ RSpec.describe Morandi, '#process' do
         expect(processed_image_width).to eq(original_image_width)
         expect(processed_image_height).to eq(original_image_height)
 
-        expect(file_out).to match_reference_image('plasma-bordered-dominant')
+        expect(file_out).to match_reference_image('plasma-bordered-retro-style')
       end
     end
 
-    context 'black colour background' do
-      let(:background_style) { 'black' }
+    describe 'when applying multiple transformations' do
+      let(:desired_image_width) { 300 }
+      let(:desired_image_height) { 260 }
 
-      it 'should maintain the target size' do
+      let(:options) do
+        {
+          'brighten' => 5,
+          'contrast' => 5,
+          'sharpen' => 2,
+          'fx' => 'greyscale',
+          'border-style' => 'solid',
+          'background-style' => '#00FF00',
+          'crop' => [50, 0, 750, 650],
+          'output.width' => desired_image_width,
+          'output.height' => desired_image_height,
+          'output.limit' => true
+        }
+      end
+
+      it 'should shrink the image to the desired dimensions' do
         process_image
 
         expect(File).to exist(file_out)
         expect(processed_image_type).to eq('jpeg')
-        expect(processed_image_width).to eq(original_image_width)
-        expect(processed_image_height).to eq(original_image_height)
+        expect(processed_image_width).to eq(desired_image_width)
+        expect(processed_image_height).to eq(desired_image_height)
 
-        expect(file_out).to match_reference_image('plasma-bordered-black')
+        expect(file_out).to match_reference_image('plasma-multiple-transformations')
       end
-    end
-
-    context 'white colour background' do
-      let(:background_style) { 'white' }
-
-      it 'should maintain the target size' do
-        process_image
-
-        expect(File).to exist(file_out)
-        expect(processed_image_type).to eq('jpeg')
-        expect(processed_image_width).to eq(original_image_width)
-        expect(processed_image_height).to eq(original_image_height)
-
-        expect(file_out).to match_reference_image('plasma-bordered-white')
-      end
-    end
-
-    context 'retro colour background' do
-      let(:background_style) { 'retro' }
-
-      it 'should maintain the target size' do
-        process_image
-
-        expect(File).to exist(file_out)
-        expect(processed_image_type).to eq('jpeg')
-        expect(processed_image_width).to eq(original_image_width)
-        expect(processed_image_height).to eq(original_image_height)
-
-        expect(file_out).to match_reference_image('plasma-bordered-retro-background')
-      end
-    end
-  end
-
-  describe 'when applying a retro border and maintaining the original size' do
-    let(:options) do
-      {
-        'border-style' => 'retro',
-        'background-style' => 'dominant',
-        'border-size-mm' => 5,
-        'output.width' => original_image_width,
-        'output.height' => original_image_height
-      }
-    end
-
-    it 'should maintain the target size' do
-      process_image
-
-      expect(File).to exist(file_out)
-      expect(processed_image_type).to eq('jpeg')
-      expect(processed_image_width).to eq(original_image_width)
-      expect(processed_image_height).to eq(original_image_height)
-
-      expect(file_out).to match_reference_image('plasma-bordered-retro-style')
-    end
-  end
-
-  describe 'when applying multiple transformations' do
-    let(:desired_image_width) { 300 }
-    let(:desired_image_height) { 260 }
-
-    let(:options) do
-      {
-        'brighten' => 5,
-        'contrast' => 5,
-        'sharpen' => 2,
-        'fx' => 'greyscale',
-        'border-style' => 'solid',
-        'background-style' => '#00FF00',
-        'crop' => [50, 0, 750, 650],
-        'output.width' => desired_image_width,
-        'output.height' => desired_image_height,
-        'output.limit' => true
-      }
-    end
-
-    it 'should shrink the image to the desired dimensions' do
-      process_image
-
-      expect(File).to exist(file_out)
-      expect(processed_image_type).to eq('jpeg')
-      expect(processed_image_width).to eq(desired_image_width)
-      expect(processed_image_height).to eq(desired_image_height)
-
-      expect(file_out).to match_reference_image('plasma-multiple-transformations')
-    end
-  end
-
-  context 'with non-sRGB colour profile' do
-    let(:file_in) { 'spec/fixtures/pumpkins-icc-adobe-rgb-1998.jpg' }
-
-    it 'converts the profile to sRGB' do
-      process_image
-
-      expect(file_out).to match_reference_image('pumpkins-icc-adobe-rgb-1998-processed-without-modifications')
-    end
-  end
-
-  context 'with increasing quality settings' do
-    let!(:max_quality_file) do
-      Morandi.process(file_in, { 'quality' => 100 }, 'sample/out-100.jpg')
-    end
-
-    let(:max_quality_file_size) { File.size('sample/out-100.jpg') }
-
-    let!(:default_of_97_quality_file) do
-      Morandi.process(file_in, {}, 'sample/out-97.jpg')
-    end
-
-    let(:default_of_97_quality_file_size) { File.size('sample/out-97.jpg') }
-
-    let!(:quality_of_40_file) do
-      Morandi.process(file_in, { 'quality' => 40 }, 'sample/out-40.jpg')
-    end
-
-    let(:quality_of_40_file_size) { File.size('sample/out-40.jpg') }
-
-    let(:created_file_sizes) do
-      [default_of_97_quality_file_size, max_quality_file_size, quality_of_40_file_size]
-    end
-
-    let(:files_in_increasing_quality_order) do
-      [quality_of_40_file_size, default_of_97_quality_file_size, max_quality_file_size]
-    end
-
-    it 'creates files of increasing size' do
-      expect(created_file_sizes.sort).to eq(files_in_increasing_quality_order)
     end
   end
 end

--- a/spec/support/match_reference_image.rb
+++ b/spec/support/match_reference_image.rb
@@ -73,7 +73,7 @@ RSpec::Matchers.define :match_reference_image do |reference_name, file_type: 'jp
     return true if @normalized_mean_error <= tolerance
 
     metadata = RSpec.current_example.metadata
-    spec_name = "#{metadata[:absolute_file_path].split('/spec/').last}:#{metadata[:line_number]}"
+    spec_name = "#{metadata[:absolute_file_path].split('/spec/').last}:#{metadata[:scoped_id]}"
     @debug_data = Morandi::SpecSupport::ImageDebugData.new(spec_name, file_type)
 
     @debug_data.expose_from(reference_path: reference_path, tested_path: tested_path, diff_path: tmp_diff.path)


### PR DESCRIPTION
**Background**
I'm prototyping `libvips`-based Morandi on a separate branch in hope of improving its memory profile and performance. We want to provide ability to render using either Pixbuf of Vips within a single version of Morandi.

**Problems**
1. Both libraries will need to pass certain tests to be considered correct, but we'd like to avoid duplication
2. Certain tests rely on implementation details of Pixbuf

**Solutions**
1. Extract the shared operations into a `shared_examples` group (unchanged within a dedicated commit)
2. Break dependency on the implementation details

**Notes**
- Due to moving a lot of lines I suggest reviewing with whitespaces ignored
- It turned out that the image matcher was overwriting some output when using shared examples, that was addressed by using spec scope ids
- I've also included some minor adjustments which I've noticed along the way