### PR TITLE
chore: prepare 0.99.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.99.4] 18.11.2024
 ### Added
 - Better test coverage for straighten operation
 - Support for visual image comparison in specs

--- a/lib/morandi/version.rb
+++ b/lib/morandi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Morandi
-  VERSION = '0.99.03'
+  VERSION = '0.99.4'
 end


### PR DESCRIPTION
Prepping a (hopefully) last release before introducing vips dependency.

I corrected the version number not to be zero-padded (`0.99.03` -> `0.99.4`).