### PR TITLE
feat: always save vips output in srgb colourspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Vips gamma
 - Vips stripping alpha
 - Explicit error when trying to use VipsProcessor with unsupported options
+- Vips cast to srgb when image uses a different colourspace
 
 ### Removed
 - [BREAKING] dropped support for a broken 'dominant' border colour

--- a/lib/morandi/vips_image_processor.rb
+++ b/lib/morandi/vips_image_processor.rb
@@ -84,6 +84,7 @@ module Morandi
       end
 
       strip_alpha!
+      ensure_srgb!
     end
 
     def write_to_png(_write_to, _orientation = :any)
@@ -160,8 +161,8 @@ module Morandi
       filter_name = @options['fx']
       return unless SUPPORTED_FILTERS.include?(filter_name)
 
-      # The filter-related constants assume RGB colourspace, so it requires conversion
-      @img = @img.colourspace(:srgb) unless @img.interpretation == :srgb
+      # The filter-related constants assume RGB colourspace, so it requires early conversion
+      ensure_srgb!
 
       # Convert to greyscale using weights
       rgb_factors = RGB_LUMINANCE_EXTRACTION_FACTORS
@@ -184,6 +185,10 @@ module Morandi
 
     def not_equal_to_one(float)
       (float - 1.0).abs >= Float::EPSILON
+    end
+
+    def ensure_srgb!
+      @img = @img.colourspace(:srgb) unless @img.interpretation == :srgb
     end
   end
 end

--- a/spec/morandi_spec.rb
+++ b/spec/morandi_spec.rb
@@ -470,7 +470,7 @@ RSpec.describe Morandi, '#process' do
         generate_test_image_greyscale(file_in, width: original_image_width, height: original_image_height)
       end
 
-      it 'changes greyscale image to srgb', vips_wip: processor_name == 'vips' do
+      it 'changes greyscale image to srgb' do
         expect(file_in).to match_colourspace('gray') # Testing a setup to protect from a hidden regression
         process_image
 

--- a/spec/morandi_spec.rb
+++ b/spec/morandi_spec.rb
@@ -403,19 +403,19 @@ RSpec.describe Morandi, '#process' do
 
     context 'with increasing quality settings' do
       let!(:max_quality_file) do
-        Morandi.process(file_in, { 'quality' => 100 }, 'sample/out-100.jpg')
+        Morandi.process(file_in, { 'quality' => 100 }, 'sample/out-100.jpg', 'processor' => processor_name)
       end
 
       let(:max_quality_file_size) { File.size('sample/out-100.jpg') }
 
       let!(:default_of_97_quality_file) do
-        Morandi.process(file_in, {}, 'sample/out-97.jpg')
+        Morandi.process(file_in, {}, 'sample/out-97.jpg', 'processor' => processor_name)
       end
 
       let(:default_of_97_quality_file_size) { File.size('sample/out-97.jpg') }
 
       let!(:quality_of_40_file) do
-        Morandi.process(file_in, { 'quality' => 40 }, 'sample/out-40.jpg')
+        Morandi.process(file_in, { 'quality' => 40 }, 'sample/out-40.jpg', 'processor' => processor_name)
       end
 
       let(:quality_of_40_file_size) { File.size('sample/out-40.jpg') }


### PR DESCRIPTION
## Background
GdkPixbuf-based image processing can take over 1GB of memory for processing a single high-resolution photo. We've decided to introduce another processor, hoping that it'll improve Morandi's memory profile and performance. 

## Problems
By default, Vips processor retains the input colourspace when saving, which is inconsistent with how GdkPixbuf's version works

## Solution
Cast to sRGB before saving if needed

## Notes
- I've also noticed unrelated spec being broken, because the image processor wasn't set (so the same spec ran for GdkPixbuf twice)