### PR TITLE
chore: release 0.100.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## UNRELEASED
+## [0.100.0] 17.01.2024
 ### Added
 - Vips image processor (resizing)
 - Vips colour filters

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    morandi (0.99.4)
+    morandi (0.100.0)
       atk (~> 4.0)
       cairo (~> 1.0)
       colorscore (~> 0.0)

--- a/lib/morandi/version.rb
+++ b/lib/morandi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Morandi
-  VERSION = '0.99.4'
+  VERSION = '0.100.0'
 end


### PR DESCRIPTION
## Release 0.100.0
### Added
- Vips image processor (resizing)
- Vips colour filters
- Vips crop
- Vips rotate
- Vips straighten
- Vips gamma
- Vips stripping alpha
- Explicit error when trying to use VipsProcessor with unsupported options
- Vips cast to srgb when image uses a different colourspace