### PR TITLE
fix: dev environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       - name: checkout repo
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: lint code with rubocop
-        uses: andrewmcodes/rubocop-linter-action@v3.3.0
+        uses: andrewmcodes/rubocop-linter-action@c9de2ff0e58217d3aa9167324b9dabdd2c6eefbe # v3.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   tests:
@@ -44,7 +44,7 @@ jobs:
       - name: unlock the gem versions
         run: rm Gemfile.lock
       - name: set up ruby environment
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@b90be12699fdfcbee4440c2bba85f6f460446bb0 # v1.279.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
@@ -54,7 +54,7 @@ jobs:
         run: bundle exec rspec
         id: test
       - name: upload test artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: "visual-matching-results-ruby-${{ matrix.ruby}}"
           path: 'tmp/reference-image-matches'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.3-slim
+FROM ruby:3.3-slim-bookworm
 
 LABEL Name=morandirb Version=0.0.2
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build: Dockerfile
 	docker build -t ${IMAGE_NAME}:latest .
 
 run:
-	docker run -it --rm --name ${CONTAINER_NAME} -v ${PWD}:/app ${IMAGE_NAME}:latest
+	docker run -it --rm --name ${CONTAINER_NAME} -v ${PWD}:/app ${IMAGE_NAME}:latest bash -c "bundle exec rake compile && bundle exec guard"
 
 shell:
 	docker exec -it ${CONTAINER_NAME} /bin/bash

--- a/lib/morandi/image_processor.rb
+++ b/lib/morandi/image_processor.rb
@@ -126,7 +126,7 @@ module Morandi
         @pb = MorandiNative::PixbufUtils.brightness(@pb, brighten)
       end
 
-      if options['gamma'] && not_equal_to_one(options['gamma'])
+      if options['gamma'] && not_equal_to_one?(options['gamma'])
         @pb = MorandiNative::PixbufUtils.gamma(@pb,
                                                options['gamma'])
       end
@@ -197,7 +197,7 @@ module Morandi
       # can't crop, won't crop
       return if @width.nil? && @height.nil? && crop.nil?
 
-      crop = crop.map { |s| (s.to_f * @scale).floor } if crop && not_equal_to_one(@scale)
+      crop = crop.map { |s| (s.to_f * @scale).floor } if crop && not_equal_to_one?(@scale)
 
       crop ||= Morandi::CropUtils.autocrop_coords(@pb.width, @pb.height, @width, @height)
 
@@ -226,7 +226,7 @@ module Morandi
       colour ||= 'black'
 
       crop = options['crop']
-      crop = crop.map { |s| (s.to_f * @scale).floor } if crop && not_equal_to_one(@scale)
+      crop = crop.map { |s| (s.to_f * @scale).floor } if crop && not_equal_to_one?(@scale)
 
       op = Morandi::Operation::ImageBorder.new_from_hash(
         'style' => style,
@@ -243,7 +243,7 @@ module Morandi
 
     private
 
-    def not_equal_to_one(float)
+    def not_equal_to_one?(float)
       (float - 1.0).abs >= Float::EPSILON
     end
   end

--- a/lib/morandi/operation/image_border.rb
+++ b/lib/morandi/operation/image_border.rb
@@ -16,7 +16,7 @@ module Morandi
         return pixbuf unless %w[square retro].include? @style
 
         create_pixbuf_from_image_surface(:rgb24, pixbuf.width, pixbuf.height) do |cr|
-          if @crop && ((@crop[0]).negative? || (@crop[1]).negative?)
+          if @crop && (@crop[0].negative? || @crop[1].negative?)
             img_width = size[0]
             img_height = size[1]
           else
@@ -38,7 +38,7 @@ module Morandi
           # Should be less than 1
           pb_scale = (longest_side - (border_width * 2)) / longest_side
 
-          if @crop && ((@crop[0]).negative? || (@crop[1]).negative?)
+          if @crop && (@crop[0].negative? || @crop[1].negative?)
             x -= @crop[0]
             y -= @crop[1]
           end
@@ -77,7 +77,7 @@ module Morandi
 
       def draw_background(cr, img_height, img_width)
         cr.save do
-          cr.translate(-@crop[0], -@crop[1]) if @crop && ((@crop[0]).negative? || (@crop[1]).negative?)
+          cr.translate(-@crop[0], -@crop[1]) if @crop && (@crop[0].negative? || @crop[1].negative?)
 
           cr.save do
             cr.set_operator :source

--- a/lib/morandi/vips_image_processor.rb
+++ b/lib/morandi/vips_image_processor.rb
@@ -68,7 +68,7 @@ module Morandi
       end
       if @size_limit_on_load_px
         @scale = @size_limit_on_load_px.to_f / [@img.width, @img.height].max
-        @img = @img.resize(@scale) if not_equal_to_one(@scale)
+        @img = @img.resize(@scale) if not_equal_to_one?(@scale)
       else
         @scale = 1.0
       end
@@ -113,7 +113,7 @@ module Morandi
     end
 
     def apply_gamma!
-      return unless @options['gamma'] && not_equal_to_one(@options['gamma'])
+      return unless @options['gamma'] && not_equal_to_one?(@options['gamma'])
 
       @img = @img.gamma(exponent: @options['gamma'])
     end
@@ -152,7 +152,7 @@ module Morandi
       # can't crop, won't crop
       return if @output_width.nil? && @output_height.nil? && crop.nil?
 
-      crop = crop.map { |s| (s.to_f * @scale).floor } if crop && not_equal_to_one(@scale)
+      crop = crop.map { |s| (s.to_f * @scale).floor } if crop && not_equal_to_one?(@scale)
       crop ||= Morandi::CropUtils.autocrop_coords(@img.width, @img.height, @output_width, @output_height)
       @img = Morandi::CropUtils.apply_crop_vips(@img, crop[0], crop[1], crop[2], crop[3])
     end
@@ -183,7 +183,7 @@ module Morandi
       @img = @img.linear(1.0, colour_filter_modifier)
     end
 
-    def not_equal_to_one(float)
+    def not_equal_to_one?(float)
       (float - 1.0).abs >= Float::EPSILON
     end
 

--- a/spec/morandi_spec.rb
+++ b/spec/morandi_spec.rb
@@ -231,8 +231,8 @@ RSpec.describe Morandi, '#process' do
         process_image
 
         expect(File).to exist(file_out)
-        expect(processed_image_width).to be <= (max_size)
-        expect(processed_image_height).to be <= (max_size)
+        expect(processed_image_width).to be <= max_size
+        expect(processed_image_height).to be <= max_size
 
         expect(file_out).to match_reference_image(reference_image_prefix, 'plasma-constrained-output-size',
                                                   tolerance: 0.006)

--- a/spec/support/match_reference_image.rb
+++ b/spec/support/match_reference_image.rb
@@ -66,7 +66,7 @@ module Morandi
           FileUtils.cp(diff_path, @exposed_diff_path)
         end
 
-        true
+        nil
       end
     end
   end


### PR DESCRIPTION
## Context
I was trying to update Morandi, but encountered issues:
- build errors (eg `libgdk-pixbuf2.0-dev` package not found). Turns out the default Ruby 3.3 now uses Debian Trixie
- rspec errors `"morandi_native" file not found`, caused by a missing compiled extension (it compiles in `/app/tmp`, but gets covered by a mounted volume)

## Changes
- pin base image to Bookworm
- recompile native extensions before running `guard` to ensure their availability
- pin the github actions to fix CI errors (also bumped their versions)
- style fixes