### PR TITLE
feat!: remove icc file after processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,3 @@ sample/
 Makefile
 *.rdb
 tags
-*.icc.jpg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.101.0] 14.01.2026
+### Removed
+- [BREAKING] support for custom srgb file path
+
 ## [0.100.0] 17.01.2024
 ### Added
 - Vips image processor (resizing)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [0.101.0] 14.01.2026
+### Added
+- [BREAKING] introduced automated cleanup of srgb files after processing
+
 ### Removed
 - [BREAKING] support for custom srgb file path
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CONTAINER_NAME=morandirb
 all: clean build run
 
 build: Dockerfile
-	docker build -t ${IMAGE_NAME}:latest .
+	docker buildx build -t ${IMAGE_NAME}:latest . --load
 
 run:
 	docker run -it --rm --name ${CONTAINER_NAME} -v ${PWD}:/app ${IMAGE_NAME}:latest bash -c "bundle exec rake compile && bundle exec guard"

--- a/lib/morandi.rb
+++ b/lib/morandi.rb
@@ -43,7 +43,6 @@ module Morandi
   #                                                              size of the longer edge (ignoring shorter dimension!)
   # @param target_path [String] target location for image
   # @param local_options [Hash] Hash of options other than desired transformations
-  # @option local_options [String] 'path.icc' A path to store the input after converting to sRGB colour space
   # @option local_options [String] 'processor' ('pixbuf') Name of the image processing library ('pixbuf', 'vips')
   #                                                       NOTE: vips processor only handles subset of operations,
   #                                                       see `Morandi::VipsImageProcessor.supports?` for details

--- a/lib/morandi.rb
+++ b/lib/morandi.rb
@@ -57,7 +57,10 @@ module Morandi
       cache_max = 0
       concurrency = 2 # Hardcoding to 2 for now to maintain some balance between resource usage and performance
       VipsImageProcessor.with_global_options(cache_max: cache_max, concurrency: concurrency) do
-        VipsImageProcessor.new(source, options).write_to_jpeg(target_path)
+        srgb_converted_file_path = Morandi::SrgbConversion.perform(source)
+        VipsImageProcessor.new(srgb_converted_file_path || source, options).write_to_jpeg(target_path)
+      ensure
+        FileUtils.rm_f(srgb_converted_file_path) if srgb_converted_file_path
       end
     else
       ImageProcessor.new(source, options, local_options).tap(&:result).write_to_jpeg(target_path)

--- a/lib/morandi/profiled_pixbuf.rb
+++ b/lib/morandi/profiled_pixbuf.rb
@@ -8,9 +8,7 @@ module Morandi
   # It attempts to load an image using jpegicc/littlecms to ensure that it is sRGB.
   # NOTE: pixbuf supports colour profiles, but it requires an explicit icc-profile option to embed it when saving file
   class ProfiledPixbuf < GdkPixbuf::Pixbuf
-    def initialize(path, local_options, max_size_px = nil)
-      @local_options = local_options
-
+    def initialize(path, _local_options, max_size_px = nil)
       path = srgb_path(path) || path
 
       if max_size_px
@@ -23,7 +21,7 @@ module Morandi
     private
 
     def srgb_path(original_path)
-      Morandi::SrgbConversion.perform(original_path, target_path: @local_options['path.icc'])
+      Morandi::SrgbConversion.perform(original_path)
     end
   end
 end

--- a/lib/morandi/profiled_pixbuf.rb
+++ b/lib/morandi/profiled_pixbuf.rb
@@ -9,13 +9,16 @@ module Morandi
   # NOTE: pixbuf supports colour profiles, but it requires an explicit icc-profile option to embed it when saving file
   class ProfiledPixbuf < GdkPixbuf::Pixbuf
     def initialize(path, _local_options, max_size_px = nil)
-      path = srgb_path(path) || path
+      srgb_converted_file_path = srgb_path(path)
+      path = srgb_converted_file_path || path
 
       if max_size_px
         super(file: path, width: max_size_px, height: max_size_px)
       else
         super(file: path)
       end
+    ensure
+      FileUtils.rm_f(srgb_converted_file_path) if srgb_converted_file_path
     end
 
     private

--- a/lib/morandi/srgb_conversion.rb
+++ b/lib/morandi/srgb_conversion.rb
@@ -7,12 +7,10 @@ module Morandi
   class SrgbConversion
     # Performs a conversion to srgb colour space if possible
     # Returns a path to converted file on success or nil on failure
-    def self.perform(path, target_path: nil)
+    def self.perform(path)
       return unless suitable_for_jpegicc?(path)
 
-      icc_file_path = target_path || default_icc_path(path)
-      return icc_file_path if valid_jpeg?(icc_file_path)
-
+      icc_file_path = default_icc_path(path)
       system('jpgicc', '-q97', path, icc_file_path, out: '/dev/null', err: '/dev/null')
 
       return unless valid_jpeg?(icc_file_path)

--- a/lib/morandi/srgb_conversion.rb
+++ b/lib/morandi/srgb_conversion.rb
@@ -13,7 +13,10 @@ module Morandi
       icc_file_path = default_icc_path(path)
       system('jpgicc', '-q97', path, icc_file_path, out: '/dev/null', err: '/dev/null')
 
-      return unless valid_jpeg?(icc_file_path)
+      unless valid_jpeg?(icc_file_path)
+        FileUtils.rm_f(icc_file_path) # jpgicc likes to leave an empty file after failing
+        return
+      end
 
       icc_file_path
     end

--- a/lib/morandi/version.rb
+++ b/lib/morandi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Morandi
-  VERSION = '0.100.0'
+  VERSION = '0.101.0'
 end

--- a/lib/morandi/vips_image_processor.rb
+++ b/lib/morandi/vips_image_processor.rb
@@ -55,7 +55,8 @@ module Morandi
     end
 
     def process!
-      source_file_path = Morandi::SrgbConversion.perform(@path) || @path
+      srgb_converted_file_path = Morandi::SrgbConversion.perform(@path)
+      source_file_path = srgb_converted_file_path || @path
       begin
         @img = Vips::Image.new_from_file(source_file_path)
       rescue Vips::Error => e

--- a/lib/morandi/vips_image_processor.rb
+++ b/lib/morandi/vips_image_processor.rb
@@ -55,8 +55,7 @@ module Morandi
     end
 
     def process!
-      srgb_converted_file_path = Morandi::SrgbConversion.perform(@path)
-      source_file_path = srgb_converted_file_path || @path
+      source_file_path = @path
       begin
         @img = Vips::Image.new_from_file(source_file_path)
       rescue Vips::Error => e

--- a/spec/morandi_spec.rb
+++ b/spec/morandi_spec.rb
@@ -521,59 +521,6 @@ RSpec.describe Morandi, '#process' do
       end
     end
 
-    context 'when the user supplies a path.icc in the "local_options" argument' do
-      subject(:process_image) do
-        Morandi.process(file_in, options, file_out, local_options)
-      end
-
-      let(:icc_path) { 'sample/icc_secure_test.jpg' }
-      let(:local_options) { { 'path.icc' => icc_path } }
-      let(:icc_width) { 900 }
-      let(:icc_height) { 400 }
-
-      before do
-        generate_test_image_plasma_checkers(icc_path, width: icc_width, height: icc_height)
-      end
-
-      it 'should use a file at this location as the input' do
-        process_image
-
-        expect(File).to exist(file_out)
-        expect(processed_image_width).to eq(icc_width)
-        expect(processed_image_height).to eq(icc_height)
-      end
-
-      context 'if no file at this location exists' do
-        let(:different_icc_path) { 'sample/different_secure_test.jpg' }
-        let(:local_options) { { 'path.icc' => different_icc_path } }
-
-        it 'should create one' do
-          process_image
-
-          expect(File).to exist(different_icc_path)
-        end
-      end
-    end
-
-    context 'when the user supplies a path.icc in the "options" argument' do
-      let(:icc_path) { 'sample/icc_insecure_test.jpg' }
-      let(:options) { { 'path.icc' => icc_path } }
-      let(:icc_width) { 900 }
-      let(:icc_height) { 400 }
-
-      before do
-        generate_test_image_plasma_checkers(icc_path, width: icc_width, height: icc_height)
-      end
-
-      it 'should ignore the file at this path' do
-        process_image
-
-        expect(File).to exist(file_out)
-        expect(processed_image_width).not_to eq(icc_width)
-        expect(processed_image_height).not_to eq(icc_height)
-      end
-    end
-
     context 'when given a redeye option' do
       let(:file_in) { 'spec/fixtures/public-domain-redeye-image-from-wikipedia.jpg' }
       let(:options) { { 'redeye' => [[540, 650]] } }

--- a/spec/morandi_spec.rb
+++ b/spec/morandi_spec.rb
@@ -45,9 +45,19 @@ RSpec.describe Morandi, '#process' do
     FileUtils.remove_dir('sample/')
   end
 
+  shared_examples 'tidy processor' do
+    it 'only leaves unchanged input, and a new output file with no other leftovers' do
+      expect { process_image }.to change { Dir['sample/*'].count }.by(1)
+
+      expect(File.exist?(file_in)).to eq true
+    end
+  end
+
   shared_examples 'an image processor' do |processor_name|
     let(:reference_image_prefix) { processor_name == 'pixbuf' ? '' : processor_name }
     subject(:process_image) { Morandi.process(file_arg, options, file_out, { 'processor' => processor_name }) }
+
+    it_behaves_like 'tidy processor'
 
     context 'when given an input without any options' do
       it 'creates output' do
@@ -469,6 +479,8 @@ RSpec.describe Morandi, '#process' do
       let(:generate_image) do
         generate_test_image_greyscale(file_in, width: original_image_width, height: original_image_height)
       end
+
+      it_behaves_like 'tidy processor'
 
       it 'changes greyscale image to srgb' do
         expect(file_in).to match_colourspace('gray') # Testing a setup to protect from a hidden regression

--- a/spec/visual_report_helper.rb
+++ b/spec/visual_report_helper.rb
@@ -68,8 +68,6 @@ module VisualReportHelper
           fp.puts %(<pre>#{CGI.escapeHTML(JSON.pretty_generate(example.example_group_instance.options))}</pre>)
           fp.puts %(</td><td>)
           files.each.with_index do |filename, index|
-            next if File.basename(filename) == 'sample.jpg.icc.jpg'
-
             base = name_for(filename, example, index)
             FileUtils.cp(filename, "spec/reports/#{base}")
             fp << %(<div class="img-block"><img src="#{base}" style="max-width: 300px; height: auto;"><br>)


### PR DESCRIPTION
## Context
At the beginning of image processing, Morandi applies the colour profile and saves the file with a `.icc.jpg` extension. That file never gets removed and pollutes the disk.

## Changes made
1. (BREAKING) Stop accepting `path.icc` to set an srgb location; ultimately, colourspace transformation should be performed in memory to make processing faster
2. (BREAKING) Automatically remove the `.icc.jpg` file after processing
3. Adjust the build command to work as expected with `buildx`