### PR TITLE
fix: remove obsolete colorscore gem

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,8 @@ jobs:
           push: false
   rubocop:
     runs-on: ubuntu-24.04
+    env:
+      BUNDLE_ONLY: rubocop
     steps:
       - name: checkout repo
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,14 +19,17 @@ jobs:
           file: ./Dockerfile
           push: false
   rubocop:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout repo
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - name: set up ruby environment
+        uses: ruby/setup-ruby@b90be12699fdfcbee4440c2bba85f6f460446bb0 # v1.279.0
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
       - name: lint code with rubocop
-        uses: andrewmcodes/rubocop-linter-action@c9de2ff0e58217d3aa9167324b9dabdd2c6eefbe # v3.3.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bundle exec rubocop
   tests:
     runs-on: ubuntu-24.04
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## UNRELEASED
 ### Fixed
 - Unnecessary `.so` files are no longer shipped with the gem
+- Rubocop on CI
+
+### Removed
+- Obsolete dependency on colorscore
 
 ## [0.101.0] 28.01.2026
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update && apt-get install -yyq --no-install-recommends \
   libglib2.0-dev \
   libcairo2-dev \
   libgdk-pixbuf2.0-dev \
+  libatk1.0-dev \
+  libpango1.0-dev \
   imagemagick \
   liblcms2-utils \
   # When girepository tries to install implicitly, there's an error due to apt being locked; details in commit message
@@ -15,7 +17,7 @@ RUN apt-get update && apt-get install -yyq --no-install-recommends \
   time \
   libvips \
   && apt-get clean \
-  && rm -rf /va/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/*
 
 RUN gem update --system 3.4.22
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,11 @@ gem 'guard'
 gem 'guard-rspec'
 gem 'rake'
 gem 'rspec'
-gem 'rubocop'
 gem 'simplecov'
 gem 'super_diff'
 gem 'yard'
+
+# Kept in a separate group so CI can lint without installing the native gems
+group :rubocop do
+  gem 'rubocop'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,9 @@
 PATH
   remote: .
   specs:
-    morandi (0.100.0)
+    morandi (0.101.0)
       atk (~> 4.0)
       cairo (~> 1.0)
-      colorscore (~> 0.0)
       gdk_pixbuf2 (~> 4.0)
       pango (~> 4.0)
       rake-compiler (~> 1.2)
@@ -25,11 +24,9 @@ GEM
       cairo (>= 1.16.2)
       glib2 (= 4.2.4)
     coderay (1.1.3)
-    color (1.8)
-    colorscore (0.0.5)
-      color
     diff-lcs (1.5.1)
     docile (1.4.1)
+    ffi (1.17.0-aarch64-linux-gnu)
     ffi (1.17.0-x86_64-linux-gnu)
     fiddle (1.1.3)
     formatador (1.1.0)
@@ -142,6 +139,7 @@ GEM
     yard (0.9.37)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -62,3 +62,8 @@ Useful, for example, to run rubocop:
 ```bash
 make shell
 ```
+
+> [!NOTE]
+> The image builds and the gem works on ARM platform, but a few specs fail with tiny rendering output mismatches.
+>
+> CI uses AMD64 and is a source of truth for the specs

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Library of simple image manipulations - replicating the behaviour of morandi-js.
 
 ## Installation
 
-Install `liblcms2-utils` to provide the `jpgicc` command used by `Morandi::ProfiledPixbuf`. Also ensure that your host system has `imagemagick` installed, which is required by the `colorscore` gem.
+Install `liblcms2-utils` to provide the `jpgicc` command used by `Morandi::ProfiledPixbuf`.
 
 Add this line to your application's Gemfile:
 

--- a/README.md
+++ b/README.md
@@ -36,4 +36,29 @@ For the detailed documentation of options see `lib/morandi.rb`
 
 ### Development
 
-Since this gem depends on the `liblcms2-utils` library, which can be awkward to install on some operating systems, we also provide a development docker image. A Makefile is also provided as a simple CLI. To build the image and run the container, type `make` from the project root. The container itself runs `guard` as its main process. Running the container via `make` will drop you into the guard prompt, which will run the test suite whenever any of the source code or tests are changed. The tests can be kicked-off manually via the `all` command at the guard prompt. Individual test can be run using the `focus: true` annotation on an example or describe block. If you need to access a bash shell in the container (for example, to run rubocop), use the command `make shell`.
+Development happens inside a docker image, with a Makefile provided as a simple CLI.
+
+#### Build the image and run the container
+
+```bash
+make
+```
+
+Above launches `guard`, which automatically runs tests when any file changes.
+
+#### Run the full test suite manually from the guard prompt
+```bash
+all
+```
+
+#### Run an individual test
+
+Add the `focus: true` annotation to an example or describe block.
+
+#### Open a bash shell in the container
+
+Useful, for example, to run rubocop:
+
+```bash
+make shell
+```

--- a/lib/morandi/operation/image_border.rb
+++ b/lib/morandi/operation/image_border.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'colorscore'
 require 'morandi/image_operation'
 
 module Morandi

--- a/morandi.gemspec
+++ b/morandi.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'atk', '~> 4.0'
   spec.add_dependency 'cairo', '~> 1.0'
-  spec.add_dependency 'colorscore', '~> 0.0'
   spec.add_dependency 'gdk_pixbuf2', '~> 4.0'
   spec.add_dependency 'pango', '~> 4.0'
   spec.add_dependency 'rake-compiler', '~> 1.2'


### PR DESCRIPTION
When reviewing transitive dependencies of another project, I've noticed that `morandi` [doesn't use colorscore gem anymore](https://github.com/livelink/morandi-rb/commit/a79d9308be369adc0a33d2b815b6794c9816664b), so I removed it.

Other piggybacked changes:
- fixed typo in command for cleaning up the apt lists and manually installed packages required by gem dependencies
- updated README for friendlier dev setup
- replaced unmaintained rubocop action with a direct call (it was failing due to newer version of `parallel` only supporting ruby `3.3+`)
- added a readme note about ARM quirks